### PR TITLE
slightly updated filter_disease_codes.py

### DIFF
--- a/grants_tagger/filter_disease_codes.py
+++ b/grants_tagger/filter_disease_codes.py
@@ -6,8 +6,12 @@ from pathlib import Path
 import xml.etree.ElementTree as ET
 import sys
 
-def filter_disease_codes(mesh_descriptions_file):
+import pandas as pd
+
+def filter_disease_codes(mesh_descriptions_file, mesh_export_file):
     mesh_tree = ET.parse(mesh_descriptions_file)
+    mesh_Df = pd.DataFrame(columns = ['DescriptorName', 'TreeNumberList'])
+
     for mesh in mesh_tree.getroot():
         try:
             # TreeNumberList e.g. A11.118.637.555.567.550.500.100
@@ -16,12 +20,15 @@ def filter_disease_codes(mesh_descriptions_file):
             mesh_name = mesh[1][0].text
         except IndexError:
             print("ERROR", file=sys.stderr)
-        if mesh_code.startswith('C'):
+        if mesh_code.startswith('C') and not mesh_code.startswith('C22') or mesh_code.startswith('F03'):
             print(mesh_name)
+            mesh_Df = mesh_Df.append({'DescriptorName':mesh_name, 'TreeNumberList':mesh_code}, ignore_index=True)
+    mesh_Df.to_csv(mesh_export_file)
 
 if __name__ == '__main__':
     argparser = ArgumentParser(description=__file__)
     argparser.add_argument('--mesh_descriptions_file', type=Path, help="path to xml file containing MeSH taxonomy")
+    argparser.add_argument('--mesh_export_file', type=Path, help="path to csv file to export Mesh terms")
     args = argparser.parse_args()
 
-    filter_disease_codes(args.mesh_descriptions_file)
+    filter_disease_codes(args.mesh_descriptions_file, args.mesh_export_file)


### PR DESCRIPTION
Hi Nick, 

I have made some changes in the filter_disease_codes.py which came up when I walked through it with Kirstin. They changes contribute to two items:
- previously only codes starting with a 'C' were included. We have now also included codes starting with 'F03' (mental disorders) and excluded codes starting with 'C22' (animal diseases)
- I have added some code so the resulting codes & names can be exported as a .csv, which makes it easier to check/use the output