### PR TITLE
Predict mesh

### DIFF
--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -1,0 +1,37 @@
+"""
+"""
+import pickle
+import os
+
+from scipy.sparse import hstack
+
+
+def predict_mesh_tags(X, model_path, label_binarizer_path,
+                      probabilities=False, threshold=None):
+    # TODO: generalise tfidf to vectorizer.pkl
+    with open(f"{model_path}/tfidf.pkl", "rb") as f:
+        vectorizer = pickle.loads(f.read())
+    with open(label_binarizer_path, "rb") as f:
+        label_binarizer = pickle.loads(f.read())
+
+    Y_pred_proba = []
+    for tag_i in os.listdir(model_path):
+        if tag_i == "vectorizer.pkl":
+            continue
+        with open(f"{model_path}/{tag_i}.pkl", "rb") as f:
+            classifier = pickle.loads(f.read())
+        X_vec = vectorizer.transform(X)
+        Y_pred_i = classifier.predict_proba(X_vec)
+        Y_pred_proba.append(Y_pred_i)
+    Y_pred_proba = hstack(Y_pred_proba)
+    
+    tags = []
+    for y_pred_proba in Y_pred_proba:
+        tags_i = [tag for tag, prob in zip(label_binarizer.classes_, y_pred_proba) if prob > 0.5]
+        tags.append(tags_i)
+    return tags
+
+if __name__ == '__main__':
+    X = ["malaria"]
+    tags = predict_mesh_tags(X, "disease_mesh_tfidf-svm-2020.07.0/", "models/")
+    print(tags)

--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -1,4 +1,7 @@
 """
+Predict function for disease part of mesh that optionally
+exposes probabilities and that you can set the threshold 
+for making a prediction
 """
 import pickle
 import os
@@ -32,8 +35,3 @@ def predict_mesh_tags(X, model_path, label_binarizer_path,
             tags_i = [tag for tag, prob in zip(label_binarizer.classes_, y_pred_proba) if prob > threshold]
         tags.append(tags_i)
     return tags
-
-if __name__ == '__main__':
-    X = ["malaria", "ebola"]
-    tags = predict_mesh_tags(X, "models/disease_mesh_tfidf-svm-2020.07.0/", "models/disease_mesh_label_binarizer.pkl", probabilities=True)
-    print(tags)

--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -10,7 +10,8 @@ from numpy import hstack
 
 
 def predict_mesh_tags(X, model_path, label_binarizer_path,
-                      probabilities=False, threshold=0.5):
+                      probabilities=False, threshold=0.5,
+                      y_batch_size=512):
     # TODO: generalise tfidf to vectorizer.pkl
     with open(f"{model_path}/tfidf.pkl", "rb") as f:
         vectorizer = pickle.loads(f.read())
@@ -19,7 +20,7 @@ def predict_mesh_tags(X, model_path, label_binarizer_path,
 
     nb_labels = len(label_binarizer.classes_)
     Y_pred_proba = []
-    for tag_i in range(0, nb_labels, 512):
+    for tag_i in range(0, nb_labels, y_batch_size):
         with open(f"{model_path}/{tag_i}.pkl", "rb") as f:
             classifier = pickle.loads(f.read())
         X_vec = vectorizer.transform(X)

--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -3,7 +3,7 @@
 import pickle
 import os
 
-from scipy.sparse import hstack
+from numpy import hstack
 
 
 def predict_mesh_tags(X, model_path, label_binarizer_path,
@@ -14,10 +14,9 @@ def predict_mesh_tags(X, model_path, label_binarizer_path,
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
 
+    nb_labels = len(label_binarizer.classes_)
     Y_pred_proba = []
-    for tag_i in os.listdir(model_path):
-        if tag_i == "vectorizer.pkl":
-            continue
+    for tag_i in range(0, nb_labels, 512):
         with open(f"{model_path}/{tag_i}.pkl", "rb") as f:
             classifier = pickle.loads(f.read())
         X_vec = vectorizer.transform(X)
@@ -32,6 +31,6 @@ def predict_mesh_tags(X, model_path, label_binarizer_path,
     return tags
 
 if __name__ == '__main__':
-    X = ["malaria"]
-    tags = predict_mesh_tags(X, "disease_mesh_tfidf-svm-2020.07.0/", "models/")
+    X = ["malaria", "ebola"]
+    tags = predict_mesh_tags(X, "models/disease_mesh_tfidf-svm-2020.07.0/", "models/disease_mesh_label_binarizer.pkl")
     print(tags)

--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -30,7 +30,7 @@ def predict_mesh_tags(X, model_path, label_binarizer_path,
     tags = []
     for y_pred_proba in Y_pred_proba:
         if probabilities:
-            tags_i = {tag: prob for tag, prob in zip(label_binarizer.classes_, y_pred_proba) if prob > threshold}
+            tags_i = {tag: prob for tag, prob in zip(label_binarizer.classes_, y_pred_proba)}
         else:
             tags_i = [tag for tag, prob in zip(label_binarizer.classes_, y_pred_proba) if prob > threshold]
         tags.append(tags_i)

--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -7,7 +7,7 @@ from numpy import hstack
 
 
 def predict_mesh_tags(X, model_path, label_binarizer_path,
-                      probabilities=False, threshold=None):
+                      probabilities=False, threshold=0.5):
     # TODO: generalise tfidf to vectorizer.pkl
     with open(f"{model_path}/tfidf.pkl", "rb") as f:
         vectorizer = pickle.loads(f.read())
@@ -26,11 +26,14 @@ def predict_mesh_tags(X, model_path, label_binarizer_path,
     
     tags = []
     for y_pred_proba in Y_pred_proba:
-        tags_i = [tag for tag, prob in zip(label_binarizer.classes_, y_pred_proba) if prob > 0.5]
+        if probabilities:
+            tags_i = {tag: prob for tag, prob in zip(label_binarizer.classes_, y_pred_proba) if prob > threshold}
+        else:
+            tags_i = [tag for tag, prob in zip(label_binarizer.classes_, y_pred_proba) if prob > threshold]
         tags.append(tags_i)
     return tags
 
 if __name__ == '__main__':
     X = ["malaria", "ebola"]
-    tags = predict_mesh_tags(X, "models/disease_mesh_tfidf-svm-2020.07.0/", "models/disease_mesh_label_binarizer.pkl")
+    tags = predict_mesh_tags(X, "models/disease_mesh_tfidf-svm-2020.07.0/", "models/disease_mesh_label_binarizer.pkl", probabilities=True)
     print(tags)

--- a/grants_tagger/tag_grants_with_mesh.py
+++ b/grants_tagger/tag_grants_with_mesh.py
@@ -7,8 +7,8 @@ import csv
 
 from grants_tagger.predict_mesh import predict_mesh_tags as predict_tags
 
-MODEL_PATH = "models/disease_mesh_tfidf-svm-2020.07.0/"
-LABEL_BINARIZER_PATH = "models/disease_mesh_label_binarizer.pkl"
+DEFAULT_MODEL_PATH = "models/disease_mesh_tfidf-svm-2020.07.0/"
+DEFAULT_LABEL_BINARIZER_PATH = "models/disease_mesh_label_binarizer.pkl"
 
 def yield_grants(grants_path):
     """yields grants row by row from file"""
@@ -42,7 +42,7 @@ def yield_tagged_grants(grants, tags):
         })
         yield tagged_grant
 
-def tag_grants_with_mesh(grants_path, tagged_grants_path, model_path=MODEL_PATH, label_binarizer_path=LABEL_BINARIZER_PATH):
+def tag_grants_with_mesh(grants_path, tagged_grants_path, model_path, label_binarizer_path):
     grants = [g for g in yield_grants(grants_path)]
     grants_text = [grant['title'] + ' ' + grant['synopsis'] for grant in grants]
     tags = predict_tags(grants_text, model_path=model_path, label_binarizer_path=label_binarizer_path)
@@ -62,6 +62,8 @@ if __name__ == '__main__':
     argparser = ArgumentParser(description=__file__)
     argparser.add_argument('--grants', type=Path, help="")
     argparser.add_argument('--tagged_grants', type=Path, help="")
+    argparser.add_argument('--model_path', type=Path, default=DEFAULT_MODEL_PATH, help="")
+    argparser.add_argument('--label_binarizer_path', type=Path, default=DEFAULT_LABEL_BINARIZER_PATH, help="")
     args = argparser.parse_args()
 
-    tag_grants_with_mesh(args.grants, args.tagged_grants)
+    tag_grants_with_mesh(args.grants, args.tagged_grants, args.model_path, args.label_binarizer_path)

--- a/grants_tagger/tag_grants_with_mesh.py
+++ b/grants_tagger/tag_grants_with_mesh.py
@@ -47,7 +47,7 @@ def tag_grants_with_mesh(grants_path, tagged_grants_path, model_path=MODEL_PATH,
     grants_text = [grant['title'] + ' ' + grant['synopsis'] for grant in grants]
     tags = predict_tags(grants_text, model_path=model_path, label_binarizer_path=label_binarizer_path)
     
-    with open(args.tagged_grants, 'w') as f_o:
+    with open(tagged_grants_path, 'w') as f_o:
         fieldnames = ["Grant ID", "Reference", "Grant No."]
         fieldnames += [f"Science Category#{i}" for i in range(1,8)]
         fieldnames += [f"Disease Category#{i}" for i in range(1,6)]

--- a/grants_tagger/tag_grants_with_mesh.py
+++ b/grants_tagger/tag_grants_with_mesh.py
@@ -27,7 +27,7 @@ def yield_tagged_grants(grants, tags):
         tagged_grant: dict with keys
             Grant ID, Reference, Grant No
             ScienceCategory#{1..9}
-            DiseaseCategory#{1..9)
+            DiseaseCategory#{1..6)
     """
     for grant, tags in zip(grants, tags):
         tagged_grant = {
@@ -42,10 +42,10 @@ def yield_tagged_grants(grants, tags):
         })
         yield tagged_grant
 
-def tag_grants_with_mesh(grants_path, tagged_grants_path):
+def tag_grants_with_mesh(grants_path, tagged_grants_path, model_path=MODEL_PATH, label_binarizer_path=LABEL_BINARIZER_PATH):
     grants = [g for g in yield_grants(grants_path)]
     grants_text = [grant['title'] + ' ' + grant['synopsis'] for grant in grants]
-    tags = predict_tags(grants_text, model_path=MODEL_PATH, label_binarizer_path=LABEL_BINARIZER_PATH)
+    tags = predict_tags(grants_text, model_path=model_path, label_binarizer_path=label_binarizer_path)
     
     with open(args.tagged_grants, 'w') as f_o:
         fieldnames = ["Grant ID", "Reference", "Grant No."]

--- a/grants_tagger/tag_grants_with_mesh.py
+++ b/grants_tagger/tag_grants_with_mesh.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 import csv
 
-from grants_tagger.predict_mesh import predict_tags
+from grants_tagger.predict_mesh import predict_mesh_tags as predict_tags
 
 MODEL_PATH = "models/disease_mesh_tfidf-svm-2020.07.0/"
 LABEL_BINARIZER_PATH = "models/disease_mesh_label_binarizer.pkl"
@@ -38,6 +38,7 @@ def yield_tagged_grants(grants, tags):
         tagged_grant.update({
             f"Disease Category#{i+1}": tag
             for i, tag in enumerate(tags)
+            if i < 5
         })
         yield tagged_grant
 
@@ -61,6 +62,6 @@ if __name__ == '__main__':
     argparser = ArgumentParser(description=__file__)
     argparser.add_argument('--grants', type=Path, help="")
     argparser.add_argument('--tagged_grants', type=Path, help="")
-    args = argparser.parse_args
+    args = argparser.parse_args()
 
     tag_grants_with_mesh(args.grants, args.tagged_grants)

--- a/grants_tagger/tag_grants_with_mesh.py
+++ b/grants_tagger/tag_grants_with_mesh.py
@@ -60,10 +60,10 @@ def tag_grants_with_mesh(grants_path, tagged_grants_path, model_path, label_bina
 
 if __name__ == '__main__':
     argparser = ArgumentParser(description=__file__)
-    argparser.add_argument('--grants', type=Path, help="")
-    argparser.add_argument('--tagged_grants', type=Path, help="")
-    argparser.add_argument('--model_path', type=Path, default=DEFAULT_MODEL_PATH, help="")
-    argparser.add_argument('--label_binarizer_path', type=Path, default=DEFAULT_LABEL_BINARIZER_PATH, help="")
+    argparser.add_argument('--grants', type=Path, help="path to grants csv with title, synopsis")
+    argparser.add_argument('--tagged_grants', type=Path, help="path to output the tagged grants")
+    argparser.add_argument('--model_path', type=Path, default=DEFAULT_MODEL_PATH, help="path to a dir that contains the batched models")
+    argparser.add_argument('--label_binarizer_path', type=Path, default=DEFAULT_LABEL_BINARIZER_PATH, help="path to mesh label binarizer")
     args = argparser.parse_args()
 
     tag_grants_with_mesh(args.grants, args.tagged_grants, args.model_path, args.label_binarizer_path)

--- a/grants_tagger/tag_grants_with_mesh.py
+++ b/grants_tagger/tag_grants_with_mesh.py
@@ -1,0 +1,66 @@
+"""
+Tag grants with MeSH tags
+"""
+from argparse import ArgumentParser
+from pathlib import Path
+import csv
+
+from grants_tagger.predict_mesh import predict_tags
+
+MODEL_PATH = "models/disease_mesh_tfidf-svm-2020.07.0/"
+LABEL_BINARIZER_PATH = "models/disease_mesh_label_binarizer.pkl"
+
+def yield_grants(grants_path):
+    """yields grants row by row from file"""
+    with open(grants_path) as f:
+        csv_reader = csv.DictReader(f)
+        for grant in csv_reader:
+            yield grant
+
+def yield_tagged_grants(grants, tags):
+    """
+    Tags grants and outputs tagged grant data structure
+
+    Args:
+        grant: dict with keys grant_id, reference, grant_no, title, synopsis
+    Returns
+        tagged_grant: dict with keys
+            Grant ID, Reference, Grant No
+            ScienceCategory#{1..9}
+            DiseaseCategory#{1..9)
+    """
+    for grant, tags in zip(grants, tags):
+        tagged_grant = {
+            'Grant ID': grant['grant_id'],
+            'Reference': grant['reference'],
+            'Grant No.': grant['grant_no']
+        }
+        tagged_grant.update({
+            f"Disease Category#{i+1}": tag
+            for i, tag in enumerate(tags)
+        })
+        yield tagged_grant
+
+def tag_grants_with_mesh(grants_path, tagged_grants_path):
+    grants = [g for g in yield_grants(grants_path)]
+    grants_text = [grant['title'] + ' ' + grant['synopsis'] for grant in grants]
+    tags = predict_tags(grants_text, model_path=MODEL_PATH, label_binarizer_path=LABEL_BINARIZER_PATH)
+    
+    with open(args.tagged_grants, 'w') as f_o:
+        fieldnames = ["Grant ID", "Reference", "Grant No."]
+        fieldnames += [f"Science Category#{i}" for i in range(1,8)]
+        fieldnames += [f"Disease Category#{i}" for i in range(1,6)]
+        csv_writer = csv.DictWriter(f_o, fieldnames=fieldnames)
+        csv_writer.writeheader()
+        for i, tagged_grant in enumerate(yield_tagged_grants(grants, tags)):
+            if i % 100 == 0:
+                print(i)
+            csv_writer.writerow(tagged_grant)
+
+if __name__ == '__main__':
+    argparser = ArgumentParser(description=__file__)
+    argparser.add_argument('--grants', type=Path, help="")
+    argparser.add_argument('--tagged_grants', type=Path, help="")
+    args = argparser.parse_args
+
+    tag_grants_with_mesh(args.grants, args.tagged_grants)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description='A machine learning model to tag grants',
     packages=find_packages(),
     include_package_data=True,
-    version='2020.07.1',
+    version='2020.07.2',
     package_data={'': extra_files},
     install_requires=[
         'pandas',

--- a/tests/test_predict_mesh.py
+++ b/tests/test_predict_mesh.py
@@ -1,0 +1,58 @@
+import tempfile
+import shutil
+import pickle
+import os
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.preprocessing import MultiLabelBinarizer
+from sklearn.multiclass import OneVsRestClassifier
+from sklearn.linear_model import SGDClassifier
+
+from grants_tagger.predict_mesh import predict_mesh_tags
+
+X = [
+    "all",
+    "one two",
+    "two",
+    "two hundred",
+    "one thousand"
+]
+Y = [
+    [str(i) for i in range(5000)],
+    ["1", "2"],
+    ["2"],
+    ["200"],
+    ["1000"]
+]
+
+def train_test_model(model_path, label_binarizer_path):
+    tfidf = TfidfVectorizer()
+    tfidf.fit(X)
+    with open(f"{model_path}/tfidf.pkl", "wb") as f:
+        f.write(pickle.dumps(tfidf))
+
+    X_vec = tfidf.transform(X)
+
+    label_binarizer = MultiLabelBinarizer()
+    label_binarizer.fit(Y)
+    with open(f"{label_binarizer_path}", "wb") as f:
+        f.write(pickle.dumps(label_binarizer))
+        f.seek(0)
+
+    Y_vec = label_binarizer.transform(Y)
+
+    for tag_i in range(0, Y_vec.shape[1], 512):
+        model = OneVsRestClassifier(SGDClassifier(loss='log'))
+        model.fit(X_vec, Y_vec[:, tag_i:tag_i+512])
+        with open(f"{model_path}/{tag_i}.pkl", "wb") as f:
+            f.write(pickle.dumps(model))
+
+def test_predict_mesh():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        model_path = f"{tmp_dir}/model/"
+        os.mkdir(model_path)
+        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
+        train_test_model(model_path, label_binarizer_path)
+
+        tags = predict_mesh_tags(X, model_path, label_binarizer_path)
+        assert len(tags) == 5

--- a/tests/test_tag_grants_with_mesh.py
+++ b/tests/test_tag_grants_with_mesh.py
@@ -1,0 +1,77 @@
+import tempfile
+import shutil
+import pickle
+import csv
+import os
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.preprocessing import MultiLabelBinarizer
+from sklearn.multiclass import OneVsRestClassifier
+from sklearn.linear_model import SGDClassifier
+
+from grants_tagger.tag_grants_with_mesh import tag_grants_with_mesh
+
+X = [
+    "all",
+    "one two",
+    "two",
+    "two hundred",
+    "one thousand"
+]
+Y = [
+    [str(i) for i in range(5000)],
+    ["1", "2"],
+    ["2"],
+    ["200"],
+    ["1000"]
+]
+
+def train_test_model(model_path, label_binarizer_path):
+    tfidf = TfidfVectorizer()
+    tfidf.fit(X)
+    with open(f"{model_path}/tfidf.pkl", "wb") as f:
+        f.write(pickle.dumps(tfidf))
+
+    X_vec = tfidf.transform(X)
+
+    label_binarizer = MultiLabelBinarizer()
+    label_binarizer.fit(Y)
+    with open(f"{label_binarizer_path}", "wb") as f:
+        f.write(pickle.dumps(label_binarizer))
+        f.seek(0)
+
+    Y_vec = label_binarizer.transform(Y)
+
+    for tag_i in range(0, Y_vec.shape[1], 512):
+        model = OneVsRestClassifier(SGDClassifier(loss='log'))
+        model.fit(X_vec, Y_vec[:, tag_i:tag_i+512])
+        with open(f"{model_path}/{tag_i}.pkl", "wb") as f:
+            f.write(pickle.dumps(model))
+
+def test_tag_grants_with_mesh():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        model_path = f"{tmp_dir}/model/"
+        os.mkdir(model_path)
+        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
+        train_test_model(model_path, label_binarizer_path)
+
+        with tempfile.NamedTemporaryFile(mode="w+") as tmp_grants:
+            csvwriter = csv.DictWriter(tmp_grants, fieldnames=["title", "synopsis", "grant_id", "grant_no", "reference"])
+            csvwriter.writeheader()
+
+            for i, x in enumerate(X):
+                csvwriter.writerow({
+                    "title": "",
+                    "synopsis": x,
+                    "grant_id": i,
+                    "reference": i,
+                    "grant_no": i
+                })
+
+            tmp_grants.seek(0)
+            grants_path = tmp_grants.name
+
+            tmp_tagged_grants = tempfile.NamedTemporaryFile()
+            tagged_grants_path = tmp_tagged_grants.name
+
+            tag_grants_with_mesh(grants_path, tagged_grants_path, model_path=model_path, label_binarizer_path=label_binarizer_path)

--- a/tests/test_tag_grants_with_mesh.py
+++ b/tests/test_tag_grants_with_mesh.py
@@ -55,7 +55,9 @@ def test_tag_grants_with_mesh():
         label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
         train_test_model(model_path, label_binarizer_path)
 
-        with tempfile.NamedTemporaryFile(mode="w+") as tmp_grants:
+        tagged_grants_path = f"{tmp_dir}/tagged_grants.csv"
+        grants_path = f"{tmp_dir}/grants.csv"
+        with open(grants_path, "w") as tmp_grants:
             csvwriter = csv.DictWriter(tmp_grants, fieldnames=["title", "synopsis", "grant_id", "grant_no", "reference"])
             csvwriter.writeheader()
 
@@ -69,9 +71,5 @@ def test_tag_grants_with_mesh():
                 })
 
             tmp_grants.seek(0)
-            grants_path = tmp_grants.name
-
-            tmp_tagged_grants = tempfile.NamedTemporaryFile()
-            tagged_grants_path = tmp_tagged_grants.name
 
             tag_grants_with_mesh(grants_path, tagged_grants_path, model_path=model_path, label_binarizer_path=label_binarizer_path)


### PR DESCRIPTION
This PR exposes a predict function for tagging grants with mesh. It also creates a function to tag grants which is used for quality controls but could be more closely align with the function / task that runs in airflow / argo.

It also updated the version to reflect these changes which will be required when integrating with argo.

In the spirit of increasing test coverage I wrote tests which make a heavy use of temp files due to the nature of the functions i am testing. If there is a better way to write those tests by refactoring some code do say. A bit of the test code is repeated as well which I think is common in tests but again if there is a better way i am keen to hear it.