### PR TITLE
Add faster predict and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ virtualenv:
 
 .PHONY: test
 test:
+	$(VIRTUALENV)/bin/python -m spacy download en_trf_bertbaseuncased_lg
 	$(VIRTUALENV)/bin/pytest --disable-warnings -v --cov=grants_tagger
 
 .PHONY: run_codecov

--- a/grants_tagger/predict.py
+++ b/grants_tagger/predict.py
@@ -63,6 +63,30 @@ def predict_tags(x, probabilities=False, threshold=0.5,
         tags = [tag for tag, prob in zip(tag_names, Y_pred_probs[0]) if prob > threshold]
     return tags
 
+def predict_tags_fast(X, probabilities=False, threshold=0.5):
+    label_binarizer=DEFAULT_LABELBINARIZER
+
+    Y_pred_probs = np.zeros((len(X), len(label_binarizer.classes_)))
+    for model_ in [DEFAULT_SCIBERT, DEFAULT_TFIDF_SVM]:
+        Y_pred_probs_model = model_.predict_proba(X)
+        Y_pred_probs += Y_pred_probs_model
+
+        Y_pred_probs /= 2
+
+    tag_names = label_binarizer.classes_
+
+    if probabilities:
+        tags = [
+            {tag: prob for tag, prob in zip(tag_names, Y_pred_prob)}
+            for Y_pred_prob in Y_pred_probs
+        ]
+    else:
+        tags = [
+            [tag for tag, prob in zip(tag_names, Y_pred_prob) if prob > threshold]
+            for Y_pred_prob in Y_pred_probs
+        ]
+    return tags
+
 if __name__ == "__main__":
     argparser = argparse.ArgumentParser()
     argparser.add_argument(

--- a/grants_tagger/predict.py
+++ b/grants_tagger/predict.py
@@ -19,56 +19,23 @@ DEFAULT_SCIBERT_PATH = os.path.join(FILEPATH, '../models/scibert-2020.05.5')
 DEFAULT_TFIDF_SVM_PATH = os.path.join(FILEPATH, '../models/tfidf-svm-2020.05.2.pkl')
 DEFAULT_LABELBINARIZER_PATH = os.path.join(FILEPATH, '../models/label_binarizer.pkl')
 
-DEFAULT_SCIBERT = BertClassifier()
-DEFAULT_SCIBERT.load(DEFAULT_SCIBERT_PATH)
 
-with open(DEFAULT_TFIDF_SVM_PATH, "rb") as f:
-    DEFAULT_TFIDF_SVM = pickle.loads(f.read())
+def predict_tags(X, probabilities=False, threshold=0.5,
+                 scibert_path=DEFAULT_SCIBERT_PATH,
+                 tfidf_svm_path=DEFAULT_TFIDF_SVM_PATH,
+                 label_binarizer_path=DEFAULT_LABELBINARIZER_PATH):
+    scibert = BertClassifier()
+    scibert.load(scibert_path)
 
-with open(DEFAULT_LABELBINARIZER_PATH, "rb") as f:
-    DEFAULT_LABELBINARIZER = pickle.load(f)
+    with open(tfidf_svm_path, "rb") as f:
+        tfidf_svm = pickle.loads(f.read())
 
-
-def sort_tags_probs(tags, probs, threshold):
-    """
-    Args:
-        tags: list of science tags
-        probs: list of probabilities
-    Returns:
-        sorted_tags_probs: list of tuple (tag, prob) sorted in ascending order
-    """
-    data = zip(tags.tolist()+['------ THRESHOLD ------'], probs.tolist()+[threshold])
-    sorted_tags_probs = sorted(data, key = itemgetter(1), reverse=True)
-    return sorted_tags_probs
-
-def predict_tags(x, probabilities=False, threshold=0.5,
-                 model=[DEFAULT_SCIBERT, DEFAULT_TFIDF_SVM],
-                 label_binarizer=DEFAULT_LABELBINARIZER):
-    '''Input example text when running the .py file in the terminal to return predicted grant tags - use format:'''
-    if type(model) == list: # ensemble of models
-        Y_pred_probs = np.zeros((1, len(label_binarizer.classes_)))
-        for model_ in model:
-            Y_pred_probs_model = model_.predict_proba([x])
-            Y_pred_probs += Y_pred_probs_model
-
-        Y_pred_probs /= len(model)
-    else:
-        Y_pred_probs = model.predict_proba([x])
-
-    tag_names = label_binarizer.classes_
-
-    if probabilities:
-        tags = {tag: prob for tag, prob in zip(tag_names, Y_pred_probs[0])}
-    else:
-        tags = [tag for tag, prob in zip(tag_names, Y_pred_probs[0]) if prob > threshold]
-    return tags
-
-def predict_tags_fast(X, probabilities=False, threshold=0.5):
-    label_binarizer=DEFAULT_LABELBINARIZER
+    with open(label_binarizer_path, "rb") as f:
+        label_binarizer = pickle.load(f)
 
     Y_pred_probs = np.zeros((len(X), len(label_binarizer.classes_)))
-    for model_ in [DEFAULT_SCIBERT, DEFAULT_TFIDF_SVM]:
-        Y_pred_probs_model = model_.predict_proba(X)
+    for model in [scibert, tfidf_svm]:
+        Y_pred_probs_model = model.predict_proba(X)
         Y_pred_probs += Y_pred_probs_model
 
         Y_pred_probs /= 2
@@ -90,10 +57,16 @@ def predict_tags_fast(X, probabilities=False, threshold=0.5):
 if __name__ == "__main__":
     argparser = argparse.ArgumentParser()
     argparser.add_argument(
-        "--model",
+        "--scibert",
         type=Path,
         default=DEFAULT_SCIBERT_PATH,
-        help="scikit pickled model or path to model"
+        help="path to scibert model"
+    )
+    argparser.add_argument(
+        "--tfidf_svm",
+        type=Path,
+        default=DEFAULT_TFIDF_SVM_PATH,
+        help="path to scibert model"
     )
     argparser.add_argument(
         "--label_binarizer",
@@ -115,13 +88,5 @@ if __name__ == "__main__":
 
     args = argparser.parse_args()
 
-    with open(args.model, "rb") as f:
-        model = pickle.load(f)
-
-    with open(args.label_binarizer, "rb") as f:
-        label_binarizer = pickle.load(f)
-
-    grant_tags = label_binarizer.classes_
-    y_score = model.predict_proba([args.synopsis])[0]
-    for tag, prob in sort_tags_probs(grant_tags, y_score, args.threshold):
-        print(f"{tag:60s} - {prob:.4f}")
+    tags = predict_tags([args.synopsis])
+    print(tags)

--- a/grants_tagger/tag_grants.py
+++ b/grants_tagger/tag_grants.py
@@ -4,8 +4,15 @@ Adds tags based on SciBERT model to grants extracted from the warehouse
 from pathlib import Path
 import argparse
 import csv
+import os
 
 from grants_tagger.predict import predict_tags
+
+
+FILEPATH = os.path.dirname(__file__)
+DEFAULT_SCIBERT_PATH = os.path.join(FILEPATH, '../models/scibert-2020.05.5')
+DEFAULT_TFIDF_SVM_PATH = os.path.join(FILEPATH, '../models/tfidf-svm-2020.05.2.pkl')
+DEFAULT_LABELBINARIZER_PATH = os.path.join(FILEPATH, '../models/label_binarizer.pkl')
 
 
 def yield_grants(grants_path):
@@ -15,7 +22,7 @@ def yield_grants(grants_path):
         for grant in csv_reader:
             yield grant
 
-def yield_tagged_grants(grants, threshold):
+def yield_tagged_grants(grants, scibert_path, tfidf_svm_path, label_binarizer_path, threshold):
     """
     Tags grants and outputs tagged grant data structure
 
@@ -27,8 +34,14 @@ def yield_tagged_grants(grants, threshold):
             ScienceCategory#{1..9}
             DiseaseCategory#{1..9)
     """
-    grants_texts = [grant["title"]+["synopsis"] for g in grants]
-    grants_tags = predict_tags(grants_texts, threshold=threshold)
+    grants_texts = [g["title"]+g["synopsis"] for g in grants]
+    grants_tags = predict_tags(
+        grants_texts,
+        threshold=threshold,
+        scibert_path=scibert_path,
+        tfidf_svm_path=tfidf_svm_path,
+        label_binarizer_path=label_binarizer_path
+    )
     for grant, tags in zip(grants, grants_tags):
         tagged_grant = {
             'Grant ID': grant['grant_id'],
@@ -38,17 +51,12 @@ def yield_tagged_grants(grants, threshold):
         tagged_grant.update({
             f"Science Category#{i+1}": tag
             for i, tag in enumerate(tags)
+            if i < 7
         })
         yield tagged_grant
 
-if __name__ == '__main__':
-    argparser = argparse.ArgumentParser()
-    argparser.add_argument('--grants', type=Path, help="path to grants csv")
-    argparser.add_argument('--tagged_grants', type=Path, help="path to output csv")
-    argparser.add_argument('--threshold', type=float, default=0.5, help="threshold upon which to assign tag")
-    args = argparser.parse_args()
-    
-    with open(args.tagged_grants, 'w') as f_o:
+def tag_grants(grants_path, tagged_grants_path, scibert_path, tfidf_svm_path, label_binarizer_path, threshold=0.5):
+    with open(tagged_grants_path, 'w') as f_o:
         fieldnames = ["Grant ID", "Reference", "Grant No."]
         fieldnames += [f"Science Category#{i}" for i in range(1,8)]
         fieldnames += [f"Disease Category#{i}" for i in range(1,6)]
@@ -56,11 +64,23 @@ if __name__ == '__main__':
         csv_writer.writeheader()
 
         grants = []
-        for i, grant in enumerate(yield_grants(args.grants)):
-             if i % 10 != 0:
+        for i, grant in enumerate(yield_grants(grants_path)):
+            if i % 10 != 0:
                 # keep only 1/10th
                 continue
             grants.append(grant)
         
-        for tagged_grant in yield_tagged_grants(grant, args.threshold):
+        for tagged_grant in yield_tagged_grants(grants, scibert_path, tfidf_svm_path, label_binarizer_path, threshold):
             csv_writer.writerow(tagged_grant)
+    
+if __name__ == '__main__':
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument('--grants', type=Path, help="path to grants csv")
+    argparser.add_argument('--tagged_grants', type=Path, help="path to output csv")
+    argparser.add_argument("--scibert", type=Path, default=DEFAULT_SCIBERT_PATH, help="path to scibert model")
+    argparser.add_argument("--tfidf_svm", type=Path, default=DEFAULT_TFIDF_SVM_PATH, help="path to scibert model")
+    argparser.add_argument("--label_binarizer", type=Path, default=DEFAULT_LABELBINARIZER_PATH, help="label binarizer for Y")
+    argparser.add_argument('--threshold', type=float, default=0.5, help="threshold upon which to assign tag")
+    args = argparser.parse_args()
+
+    tag_grants(args.grants, args.tagged_grants, args.scibert, args.tfidf_svm, args.label_binarizer, args.threshold)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description='A machine learning model to tag grants',
     packages=find_packages(),
     include_package_data=True,
-    version='2020.07.2',
+    version='2020.09.0',
     package_data={'': extra_files},
     install_requires=[
         'pandas',
@@ -29,7 +29,7 @@ setup(
         'scikit-learn==0.21.3',
         'nltk',
         'matplotlib',
-        'wellcomeml[deep-learning]==2020.07.0',
+        'wellcomeml[deep-learning]==2020.9.0',
         'docutils==0.15',
         'scipy==1.4.1'
     ],

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,7 +1,62 @@
-from grants_tagger.predict import predict_tags, predict_tags_fast
+import tempfile
+import shutil
+import pickle
+import os
 
-def test_predict_tags():
-    tags = predict_tags("malaria")
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.preprocessing import MultiLabelBinarizer
+from sklearn.multiclass import OneVsRestClassifier
+from sklearn.linear_model import SGDClassifier
+from sklearn.pipeline import Pipeline
+from wellcomeml.ml import BertClassifier
 
-def test_predict_tags_fast():
-    tags = predict_tags_fast(["malaria", "ebola"])
+from grants_tagger.predict import predict_tags
+
+X = [
+    "all",
+    "one two",
+    "two",
+    "four",
+    "twenty four"
+]
+Y = [
+    [str(i) for i in range(24)],
+    ["1", "2"],
+    ["2"],
+    ["4"],
+    ["24"]
+]
+
+def train_test_model(scibert_path, tfidf_svm_path, label_binarizer_path):
+    label_binarizer = MultiLabelBinarizer()
+    label_binarizer.fit(Y)
+    with open(f"{label_binarizer_path}", "wb") as f:
+        f.write(pickle.dumps(label_binarizer))
+        f.seek(0)
+
+    Y_vec = label_binarizer.transform(Y)
+
+    tfidf_svm = Pipeline([
+        ('tfidf', TfidfVectorizer()),
+        ('svm', OneVsRestClassifier(SGDClassifier(loss='log')))
+    ])
+    
+    tfidf_svm.fit(X, Y_vec)
+    with open(tfidf_svm_path, "wb") as f:
+        f.write(pickle.dumps(tfidf_svm))
+
+    scibert = BertClassifier()
+    scibert.fit(X, Y_vec)
+    scibert.save(scibert_path)
+
+def test_predict_mesh():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        scibert_path = f"{tmp_dir}/model/"
+        os.mkdir(scibert_path)
+        tfidf_svm_path = f"{tmp_dir}/tfidf_svm.pkl"
+        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
+        train_test_model(scibert_path, tfidf_svm_path, label_binarizer_path)
+
+        tags = predict_tags(X, scibert_path=scibert_path, tfidf_svm_path=tfidf_svm_path,
+                            label_binarizer_path=label_binarizer_path)
+        assert len(tags) == 5

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,7 @@
+from grants_tagger.predict import predict_tags, predict_tags_fast
+
+def test_predict_tags():
+    tags = predict_tags("malaria")
+
+def test_predict_tags_fast():
+    tags = predict_tags_fast(["malaria", "ebola"])

--- a/tests/test_tag_grants.py
+++ b/tests/test_tag_grants.py
@@ -1,0 +1,78 @@
+import tempfile
+import shutil
+import pickle
+import csv
+import os
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.preprocessing import MultiLabelBinarizer
+from sklearn.multiclass import OneVsRestClassifier
+from sklearn.linear_model import SGDClassifier
+from sklearn.pipeline import Pipeline
+from wellcomeml.ml import BertClassifier
+
+from grants_tagger.tag_grants import tag_grants
+
+X = [
+    "all",
+    "one two",
+    "two",
+    "four",
+    "twenty four"
+]
+Y = [
+    [str(i) for i in range(24)],
+    ["1", "2"],
+    ["2"],
+    ["4"],
+    ["24"]
+]
+
+def train_test_model(scibert_path, tfidf_svm_path, label_binarizer_path):
+    label_binarizer = MultiLabelBinarizer()
+    label_binarizer.fit(Y)
+    with open(f"{label_binarizer_path}", "wb") as f:
+        f.write(pickle.dumps(label_binarizer))
+        f.seek(0)
+
+    Y_vec = label_binarizer.transform(Y)
+
+    tfidf_svm = Pipeline([
+        ('tfidf', TfidfVectorizer()),
+        ('svm', OneVsRestClassifier(SGDClassifier(loss='log')))
+    ])
+    
+    tfidf_svm.fit(X, Y_vec)
+    with open(tfidf_svm_path, "wb") as f:
+        f.write(pickle.dumps(tfidf_svm))
+
+    scibert = BertClassifier()
+    scibert.fit(X, Y_vec)
+    scibert.save(scibert_path)
+
+def test_tag_grants_with_mesh():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        scibert_path = f"{tmp_dir}/model/"
+        os.mkdir(scibert_path)
+        tfidf_svm_path = f"{tmp_dir}/tfidf_svm.pkl"
+        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
+        train_test_model(scibert_path, tfidf_svm_path, label_binarizer_path)
+        
+        tagged_grants_path = f"{tmp_dir}/tagged_grants.csv"
+        grants_path = f"{tmp_dir}/grants.csv"
+        with open(grants_path, "w") as tmp_grants:
+            csvwriter = csv.DictWriter(tmp_grants, fieldnames=["title", "synopsis", "grant_id", "grant_no", "reference"])
+            csvwriter.writeheader()
+
+            for i, x in enumerate(X):
+                csvwriter.writerow({
+                    "title": "",
+                    "synopsis": x,
+                    "grant_id": i,
+                    "reference": i,
+                    "grant_no": i
+                })
+
+            tmp_grants.seek(0)
+
+            tag_grants(grants_path, tagged_grants_path, scibert_path=scibert_path, tfidf_svm_path=tfidf_svm_path, label_binarizer_path=label_binarizer_path)


### PR DESCRIPTION
Adds a new predict function for science tagging that work on multiple grants at the same time which speeds up inference because it allows for matrix multiplications to happen.

At the same time we add a similar to predict_mesh test which makes use of a test model. To do so we had to move away from hard coding the models to pass them as params. As for science tagging those models are packaged into the wheel by default the function can find them unlike mesh that models need to become available via a different route.