### PR TITLE
Add script that evaluates mesh model on our grants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VIRTUALENV := venv
 
 .PHONY:sync_data
 sync_data:
-	aws s3 sync data/ s3://$(PRIVATE_PROJECT_BUCKET)/data/
+	aws s3 sync data/raw/ s3://$(PRIVATE_PROJECT_BUCKET)/data/raw/
 	aws s3 sync s3://$(PRIVATE_PROJECT_BUCKET)/data/raw data/raw --exclude "*allMeSH*"
 
 .PHONY: sync_artifacts

--- a/docs/mesh_results.md
+++ b/docs/mesh_results.md
@@ -1,8 +1,8 @@
 # Model inventory
 
-Version   | Approach    | Micro f1 | Description
---------- | ----------- | -------- | -------
-2020.07.0 | tfidf-sgd   | 0.56     | tfidf-svm, bigrams, regularisation of 1e-9, removal of words appearing less than 5 times
+Version   | Approach    | Micro f1 in Pubs | Micro f1 in Grants | Description
+--------- | ----------- | ---------------- | ------------------ | -------
+2020.07.0 | tfidf-sgd   | 0.56             | 0.69               | tfidf-svm, bigrams, regularisation of 1e-9, removal of words appearing less than 5 times
 
 ## 2020.07.0
 

--- a/scripts/evaluate_mesh_on_grants.py
+++ b/scripts/evaluate_mesh_on_grants.py
@@ -1,0 +1,46 @@
+"""
+Evaluate MeSH model on grants annotated with MeSH
+
+The script works on an Excel file that contains 
+columns that follow the pattern below
+Disease MeSH#TAG_INDEX (ANNOTATOR)
+"""
+from argparse import ArgumentParser
+from pathlib import Path
+import pickle
+
+from sklearn.metrics import classification_report
+import pandas as pd
+
+
+def get_tags(data, annotator):
+    tag_columns = [col for col in data.columns if annotator in col]
+    tags = []
+    for _, row in data.iterrows():
+        row_tags = [tag for tag in row[tag_columns] if not pd.isnull(tag)]
+        tags.append(row_tags)
+    return tags
+
+def evaluate_mesh_on_grants(data_path, label_binarizer_path):
+    data = pd.read_excel(data_path)
+
+    with open(label_binarizer_path, "rb") as f:
+        label_binarizer = pickle.loads(f.read())
+
+    gold_tags = get_tags(data, "KW")
+    model_tags = get_tags(data, "NS")
+    Y = label_binarizer.transform(gold_tags)
+    Y_pred = label_binarizer.transform(model_tags)
+#    print(classification_report(Y, Y_pred, target_names=label_binarizer.classes_))
+
+    unique_tags = len(set([t for tags in gold_tags for t in tags]))
+    all_tags = len(label_binarizer.classes_)
+    print(f"Gold dataset contains examples from {unique_tags} tags out of {all_tags}")
+
+if __name__ == '__main__':
+    argparser = ArgumentParser()
+    argparser.add_argument('--data_path', type=Path, help="path to validation data")
+    argparser.add_argument('--label_binarizer_path', type=Path, help="path to disease label binarizer")
+    args = argparser.parse_args()
+
+    evaluate_mesh_on_grants(args.data_path, args.label_binarizer_path)

--- a/scripts/evaluate_mesh_on_grants.py
+++ b/scripts/evaluate_mesh_on_grants.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 import pickle
 
-from sklearn.metrics import classification_report
+from sklearn.metrics import f1_score
 import pandas as pd
 
 
@@ -31,7 +31,8 @@ def evaluate_mesh_on_grants(data_path, label_binarizer_path):
     model_tags = get_tags(data, "NS")
     Y = label_binarizer.transform(gold_tags)
     Y_pred = label_binarizer.transform(model_tags)
-#    print(classification_report(Y, Y_pred, target_names=label_binarizer.classes_))
+    f1 = f1_score(Y, Y_pred, average='micro')
+    print(f"F1 micro is {f1}")
 
     unique_tags = len(set([t for tags in gold_tags for t in tags]))
     all_tags = len(label_binarizer.classes_)


### PR DESCRIPTION
This script evaluates the current mesh model performance (tfidf-svm) in our grants data. To do that, Kirstin mapped the ICD codes that the annotators had used to MeSH.

The data collated the model predictions with the gold annotations, in the future we would like to use the model to produce the predictions so that we evaluate different models.