### PR TITLE
Calculate performance of MTI

### DIFF
--- a/docs/mesh_results.md
+++ b/docs/mesh_results.md
@@ -3,6 +3,7 @@
 Method   | Micro f1
 -------- | -------
 SciSpacy | 0.36
+MTI      | 0.49
 
 # Model inventory
 

--- a/scripts/create_mesh_sample.py
+++ b/scripts/create_mesh_sample.py
@@ -31,14 +31,26 @@ def yield_sample_data(data_path, sample_size=SAMPLE_SIZE, random_seed=RANDOM_SEE
             if i in sample_line_indices:
                 yield line
 
-def create_mesh_sample(mesh_data_path, sample_mesh_data_path):
+def create_mesh_sample(mesh_data_path, sample_mesh_data_path, mti_input_path):
+    if mti_input_path:
+        mti_f = open(mti_input_path, "w")
+
     with open(sample_mesh_data_path, "w") as f:
-        for item in yield_sample_data(mesh_data_path):
+        for i, item in enumerate(yield_sample_data(mesh_data_path)):
             f.write(item)
+
+            if mti_input_path:
+                uid = f"{i:08d}"
+                text = item["text"].encode("ascii", errors="ignore")
+                mti_f.write(f"{uid}|{text}\n")
+
+    if mti_input_path:
+        mti_f.close()
 
 argparser = ArgumentParser(description=__doc__.strip())
 argparser.add_argument("--mesh_data_path", type=Path, help="path to JSONL of processed mesh data")
 argparser.add_argument("--sample_mesh_data_path", type=Path, help="path to output sample JSONL of mesh data")
+argparser.add_argument("--mti_input_path", type=Path, default=None, help="path to output txt for MTI to use an input")
 args = argparser.parse_args()
 
-create_mesh_sample(args.mesh_data_path, args.sample_mesh_data_path)
+create_mesh_sample(args.mesh_data_path, args.sample_mesh_data_path, args.mti_input_path)

--- a/scripts/create_mesh_sample.py
+++ b/scripts/create_mesh_sample.py
@@ -40,6 +40,7 @@ def create_mesh_sample(mesh_data_path, sample_mesh_data_path, mti_input_path):
             f.write(item)
 
             if mti_input_path:
+                # MTI input format is UID|Text where UID a unique identifier
                 uid = f"{i:08d}"
                 text = item["text"].encode("ascii", errors="ignore")
                 mti_f.write(f"{uid}|{text}\n")

--- a/scripts/evaluate_mti.py
+++ b/scripts/evaluate_mti.py
@@ -1,0 +1,56 @@
+"""
+Evaluate MTI tool from NLM on MeSH subset. The subset is automatically tagged
+by MTI through an email batch service and this scripts calculates performance
+by comparing with the ground truth.
+"""
+from argparse import ArgumentParser
+from pathlib import Path
+import pickle
+import json
+import csv
+
+from sklearn.metrics import classification_report
+
+
+def get_gold_tags(mesh_sample_data_path):
+    gold_tags = []
+    with open(mesh_sample_data_path) as f:
+        for line in f:
+            item = json.loads(line)
+            gold_tags.append(item["tags"])
+    return gold_tags
+
+def get_mti_tags(mti_output_path, mesh_tags):
+    mti_data = dict()
+    with open(mti_output_path) as f:
+        csvreader = csv.reader(f, delimiter="|")
+        for line in csvreader:
+            uid, tag, _, _ = line
+            uid = int(uid)
+            if uid not in mti_data:
+                mti_data[uid] = []
+            if tag in mesh_tags:
+                mti_data[uid].append(tag)
+
+    mti_tags = [mti_data[uid] for uid in range(len(mti_data))]
+    return mti_tags
+
+def evaluate_mti(label_binarizer_path, mesh_sample_data_path, mti_output_path):
+    with open("models/disease_mesh_label_binarizer.pkl", "rb") as f:
+        label_binarizer = pickle.loads(f.read())
+    disease_tags = set(label_binarizer.classes_)
+
+    gold_tags = get_gold_tags(mesh_sample_data_path)
+    mti_tags = get_mti_tags(mti_output_path, disease_tags)
+
+    Y = label_binarizer.transform(gold_tags)
+    Y_pred = label_binarizer.transform(mti_tags)
+    print(classification_report(Y, Y_pred, target_names=label_binarizer.classes_))
+
+argparser = ArgumentParser(description=__doc__.strip())
+argparser.add_argument('--mesh_label_binarizer_path', type=Path, help="path to pickled mesh label binarizer")
+argparser.add_argument('--mesh_sample_data_path', type=Path, help="path to sample JSONL mesh data")
+argparser.add_argument('--mti_output_path', type=Path, help="path to mti output txt")
+args = argparser.parse_args()
+
+evaluate_mti(args.mesh_label_binarizer_path, args.mesh_sample_data_path, args.mti_output_path)


### PR DESCRIPTION
Extend script that creates sample to create file in MTI input format.
Add script that reads both files i.e. the sample with the gold tags and the one output that MTI batch service sents back via email and calculates performance for a subset of mesh