### PR TITLE
Fix save for CNN and BiLSTM in train

### DIFF
--- a/configs/2020.04.2.ini
+++ b/configs/2020.04.2.ini
@@ -16,6 +16,6 @@ test_data_path=
 
 [model]
 label_binarizer_path=models/label_binarizer.pkl
-model_path=models/bilstm-2020.04.2.pkl
+model_path=models/bilstm-2020.04.2
 approach=bilstm
 parameters=

--- a/configs/2020.04.3.ini
+++ b/configs/2020.04.3.ini
@@ -16,6 +16,6 @@ test_data_path=
 
 [model]
 label_binarizer_path=models/label_binarizer.pkl
-model_path=models/cnn-2020.04.3.pkl
+model_path=models/cnn-2020.04.3
 approach=cnn
 parameters=

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -270,7 +270,7 @@ def train_and_evaluate(
         print(report)
 
     if model_path:
-        if ('pkl' in str(model_path)) or ('pickle' in str(model_path)):
+        if str(model_path).endswith('pkl') or str(model_path).endswith('pickle'):
             with open(model_path, 'wb') as f:
                 pickle.dump(model, f)
         elif y_batch_size: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scikit-multilearn
 arff
 python-dateutil<2.8.1,>=2.1
--e git+git://github.com/wellcometrust/WellcomeML.git@4767c8048b4d468d5227cdc1193f19ffc3fef9ab#egg=wellcomeml[deep-learning]
+-e git+git://github.com/wellcometrust/WellcomeML.git@27b483df4df751fc2de894ca0a7441e5d2155c6b#egg=wellcomeml[deep-learning]


### PR DESCRIPTION
Fixes #32. This the problem of not being able to pickle CNNClassifier and BiLSTMClassifier. 
Fixes #34. The above problem was affecting some prior configs in the last stage of saving.
Fixes #33 . A recently introduced feature `y_batch_size` has a bug when not provided