### PR TITLE
Experiments with Team and Scheme for science tagging

### DIFF
--- a/configs/2020.10.16.ini
+++ b/configs/2020.10.16.ini
@@ -1,0 +1,23 @@
+[DEFAULT]
+version=2020.10.16
+
+[preprocess]
+input=data/raw/science_tags_full_version.xlsx
+output=data/processed/science_grants_tagged_title_synopsis_team.jsonl
+text_cols=Title,Synopsis
+meta_cols=Grant_ID,Team
+
+[label_binarizer]
+data=data/processed/science_grants_tagged_title_synopsis_team.jsonl
+label_binarizer=models/label_binarizer.pkl
+
+[data]
+train_data_path=data/processed/science_grants_tagged_title_synopsis_team.jsonl
+test_data_path=
+x_format=DataFrame
+
+[model]
+label_binarizer_path=models/label_binarizer.pkl
+model_path=models/tfidf+onehot_team-svm-2020.10.16.pkl
+approach=tfidf+onehot_team-svm
+parameters={'vectorizer__text_features__tfidf__min_df': 5, 'svm__estimator__class_weight': 'balanced', 'vectorizer__text_features__tfidf__ngram_range': (1,2)}

--- a/configs/2020.10.17.ini
+++ b/configs/2020.10.17.ini
@@ -1,0 +1,23 @@
+[DEFAULT]
+version=2020.10.17
+
+[preprocess]
+input=data/raw/science_tags_full_version.xlsx
+output=data/processed/science_grants_tagged_title_synopsis_scheme.jsonl
+text_cols=Title,Synopsis
+meta_cols=Grant_ID,Scheme
+
+[label_binarizer]
+data=data/processed/science_grants_tagged_title_synopsis_scheme.jsonl
+label_binarizer=models/label_binarizer.pkl
+
+[data]
+train_data_path=data/processed/science_grants_tagged_title_synopsis_scheme.jsonl
+test_data_path=
+x_format=DataFrame
+
+[model]
+label_binarizer_path=models/label_binarizer.pkl
+model_path=models/tfidf+onehot_scheme-svm-2020.10.17.pkl
+approach=tfidf+onehot_scheme-svm
+parameters={'vectorizer__text_features__tfidf__min_df': 5, 'svm__estimator__class_weight': 'balanced', 'vectorizer__text_features__tfidf__ngram_range': (1,2)}

--- a/docs/results.md
+++ b/docs/results.md
@@ -45,6 +45,8 @@ Version   | Approach    | Micro f1 | Description
 2020.10.13 | tfidf-svm | 0.72 | same as 2020.5.2 but train on title+synopsis and test on title+synopsis+lay summary+research question
 2020.10.14 | tfidf-svm | 0.72 | same as 2020.5.2 but train on title+synopsis and test on title+synopsis+lay summary
 2020.10.15 | tfidf-svm | 0.71 | same as 2020.5.2 but train on title+synopsis and test on title+synopsis+research_question
+2020.10.16 | tfidf+onehot_team | 0.71 | similar to 2020.5.2 but we add team as one hot variable to the features. as data get shuffled differently it seems as the performance stays the same but it actually increases 1% compared to removing the team variable
+2020.10.17 | tfidf+onehot_scheme | 0.68 | similar to 2020.10.16 but this time we add scheme as one hot variable.
 
 ## 2020.02.0
 
@@ -1593,4 +1595,76 @@ weighted avg       0.75      0.76      0.75       927
                                               macro avg       0.72      0.62      0.65       927
                                            weighted avg       0.74      0.69      0.71       927
                                             samples avg       0.74      0.72      0.69       927
+```
+
+## 2020.10.16
+
+```
+                                                         precision    recall  f1-score   support
+
+                                              10: Fungi       1.00      0.20      0.33         5
+                                          11: Parasites       0.90      0.75      0.82        24
+                     12: Brain Cells Circuits & Systems       0.84      0.84      0.84        74
+                           13: Sensory & Motor Function       0.86      0.69      0.77        26
+                              14: Behaviour & Cognition       0.70      0.82      0.76        51
+                      15: Behavioural & Social Sciences       0.48      0.52      0.50        21
+                                16: Health Intervention       0.67      0.69      0.68        54
+                          17: Health Services & Systems       0.93      0.78      0.85        32
+                                       18: Surveillance       0.49      0.82      0.62        34
+                 19: Maternal Child & Adolescent Health       0.83      0.63      0.72        30
+                                 1: Genetics & Genomics       0.61      0.56      0.58        61
+                             20: Nutrition & Metabolism       0.64      0.47      0.54        15
+                                     21: Cardiovascular       0.86      0.38      0.52        16
+                              22: Experimental Medicine       0.20      0.14      0.17        21
+                                    23: Medical Imaging       0.50      0.33      0.40         6
+24: Data Science Computational & Mathematical Modelling       0.54      0.68      0.60        38
+                2: Gene Regulation and Genome Integrity       0.78      0.70      0.74        71
+                        3: Protein Structure & Function       0.82      0.80      0.81        81
+                                        4: Cell Biology       0.61      0.76      0.67        79
+                               5: Developmental Biology       0.70      0.77      0.73        30
+                                   6: Stem Cell Biology       0.89      0.53      0.67        15
+                                          7: Immunology       0.75      0.82      0.78        72
+                                            8: Bacteria       0.89      0.63      0.74        49
+                                             9: Viruses       0.86      0.71      0.78        45
+
+                                              micro avg       0.71      0.70      0.71       950
+                                              macro avg       0.72      0.63      0.65       950
+                                           weighted avg       0.73      0.70      0.71       950
+                                            samples avg       0.74      0.74      0.71       950
+```
+
+## 2020.10.17
+
+```
+                                                         precision    recall  f1-score   support
+
+                                              10: Fungi       1.00      0.20      0.33         5
+                                          11: Parasites       0.74      0.71      0.72        24
+                     12: Brain Cells Circuits & Systems       0.86      0.80      0.83        74
+                           13: Sensory & Motor Function       0.87      0.50      0.63        26
+                              14: Behaviour & Cognition       0.74      0.78      0.76        51
+                      15: Behavioural & Social Sciences       0.44      0.38      0.41        21
+                                16: Health Intervention       0.70      0.65      0.67        54
+                          17: Health Services & Systems       0.67      0.69      0.68        32
+                                       18: Surveillance       0.60      0.62      0.61        34
+                 19: Maternal Child & Adolescent Health       0.68      0.57      0.62        30
+                                 1: Genetics & Genomics       0.56      0.56      0.56        61
+                             20: Nutrition & Metabolism       0.67      0.40      0.50        15
+                                     21: Cardiovascular       1.00      0.38      0.55        16
+                              22: Experimental Medicine       0.27      0.14      0.19        21
+                                    23: Medical Imaging       0.50      0.33      0.40         6
+24: Data Science Computational & Mathematical Modelling       0.62      0.61      0.61        38
+                2: Gene Regulation and Genome Integrity       0.79      0.68      0.73        71
+                        3: Protein Structure & Function       0.82      0.78      0.80        81
+                                        4: Cell Biology       0.62      0.77      0.69        79
+                               5: Developmental Biology       0.89      0.57      0.69        30
+                                   6: Stem Cell Biology       0.86      0.40      0.55        15
+                                          7: Immunology       0.81      0.75      0.78        72
+                                            8: Bacteria       0.93      0.57      0.71        49
+                                             9: Viruses       0.82      0.71      0.76        45
+
+                                              micro avg       0.72      0.65      0.68       950
+                                              macro avg       0.73      0.56      0.62       950
+                                           weighted avg       0.74      0.65      0.68       950
+                                            samples avg       0.74      0.69      0.67       950
 ```

--- a/grants_tagger/preprocess.py
+++ b/grants_tagger/preprocess.py
@@ -32,7 +32,9 @@ def yield_preprocess_data(
         meta: list of tuple containing meta information for a grant such as its id
     """
     # cols = ['Grant Team', 'ERG', 'Lead Applicant', 'Organisation', 'Scheme', 'Title', 'Synopsis', 'Lay Summary', 'Qu.']
-    processed_data = data.groupby('Grant_ID').agg({
+    processed_data = data.drop_duplicates(subset=["Grant_ID", "Sciencetags"])
+    processed_data = processed_data.dropna(subset=["Synopsis"])
+    processed_data = processed_data.groupby('Grant_ID').agg({
         'Sciencetags': lambda x: ",".join(x),
         'Title': lambda x: x.iloc[0],
         'Synopsis': lambda x: x.iloc[0],

--- a/grants_tagger/preprocess.py
+++ b/grants_tagger/preprocess.py
@@ -11,64 +11,12 @@ import pickle
 import json
 import os
 
-from nltk.stem import WordNetLemmatizer
 import pandas as pd
 
-
-def lemmatize(text):
-    lemmer = WordNetLemmatizer()
-    return " ".join([lemmer.lemmatize(word, 'v') for word in text.split()])
-
-def filter_missing_data(data):
-    if 'Sciencetags' not in data:
-        data['Sciencetags'] = ""
-    data.rename(columns={'Sciencetags': 'tags'}, inplace=True)
-    data = data[data['tags'] != 'No tag']
-    data = data[data['tags'] != 'Not enough information available']
-    return data
-
-def clean_text(row, lemmatize_func, text_cols, for_prodigy=False):
-    if for_prodigy:
-        title = row['Title'].upper()
-        synopsis = row['Synopsis'].replace('\n','')
-        text = f"{title}\n\n{synopsis}"
-    else:
-        text = " ".join(row[text_cols].tolist())
-    return lemmatize_func(text)
-
-def create_grant_text(data, lemmatize_func, text_cols):
-    "Return dataframe of Grant ID, text"
-    grant_data = data.copy()
-    grant_data['text'] = grant_data.apply(lambda x: clean_text(x, lemmatize_func, text_cols), axis=1)
-    grant_data = grant_data.drop_duplicates(subset = 'Grant_ID')
-    grant_data = grant_data.drop_duplicates(subset = 'Synopsis') # Drops Synopsis with No Data Entered
-    return grant_data[['Grant_ID', 'text']]
-
-def create_tagger_metadata(data, tagger_level):
-    tagger_tags_col = 'Tagger{}_tags'.format(tagger_level)
-    if 'Tagger {} only'.format(tagger_level) not in data.columns:
-        return data['Grant_ID'].drop_duplicates()
-    # create columns that define which tags each tagger used ('intersection' is the column indicating tags where both taggers agreed)
-    data[tagger_tags_col] = data['intersection'] + data['Tagger {} only'.format(tagger_level)]
-    data[tagger_tags_col] = data.apply(lambda x: x['tags'] if x['tags'] in x[tagger_tags_col] else '', axis=1)
-    d = data.groupby('Grant_ID')[tagger_tags_col].apply(lambda x: ','.join(x)).reset_index()
-    return d[['Grant_ID', tagger_tags_col]]
-
-def create_grant_metadata(data, meta_cols):
-    "Returns dataFrame containing Grant ID and metadata cols"
-    grant_metadata = data[meta_cols].drop_duplicates(subset = 'Grant_ID')
-    grant_tagger_1 = create_tagger_metadata(data, 1)
-    grant_tagger_2 = create_tagger_metadata(data, 2)
-    return grant_metadata.merge(grant_tagger_1, on='Grant_ID').merge(grant_tagger_2, on='Grant_ID')
-
-def create_grant_tags(data):
-    "Returns dataframe of Grant ID, comma separated tags"
-    grant_tags = data.groupby('Grant_ID')['tags'].apply(lambda x: ','.join(x)).reset_index()
-    return grant_tags
+# TODO: Fix keys for calculating human accuracy
 
 def yield_preprocess_data(
         data,
-        lemmatize_func=lambda x: x,
         text_cols=["Title", "Synopsis"],
         meta_cols=["Grant_ID", "Title"]):
     """
@@ -84,31 +32,35 @@ def yield_preprocess_data(
         meta: list of tuple containing meta information for a grant such as its id
     """
     # cols = ['Grant Team', 'ERG', 'Lead Applicant', 'Organisation', 'Scheme', 'Title', 'Synopsis', 'Lay Summary', 'Qu.']
-    data = data.dropna(subset=['Synopsis'])
-    data = filter_missing_data(data)
-    data = data.drop_duplicates(subset=['Grant_ID', 'tags'])
-    grant_tags = create_grant_tags(data)
-    grant_text = create_grant_text(data, lemmatize_func, text_cols)
-    grant_metadata = create_grant_metadata(data, meta_cols)
-    grant_data = grant_text.merge(grant_tags, on='Grant_ID').merge(grant_metadata, on='Grant_ID', how='left')
+    processed_data = data.groupby('Grant_ID').agg({
+        'Sciencetags': lambda x: ",".join(x),
+        'Title': lambda x: x.iloc[0],
+        'Synopsis': lambda x: x.iloc[0],
+        'Lay Summary': lambda x: x.iloc[0],
+        'Qu.': lambda x: x.iloc[0],
+        'Scheme': lambda x: x.iloc[0],
+        'Team': lambda x: x.iloc[0]
+    }).reset_index()
+    processed_data = processed_data[processed_data["Synopsis"] != "No Data Entered"]
+    processed_data = processed_data[processed_data["Sciencetags"] != "No tag"]
+    processed_data = processed_data[processed_data["Sciencetags"] != "Not enough information available"]
+    processed_data = processed_data.drop_duplicates(subset="Grant_ID")
+    processed_data = processed_data.drop_duplicates(subset="Synopsis")
+    processed_data = processed_data.replace("No Data Entered", "").fillna("")
 
-    texts = grant_data['text'].tolist()
-    tags = grant_data['tags'].tolist()
-    meta = grant_data[grant_metadata.columns].to_dict('records')
-
-    for text, tag, met in zip(texts, tags, meta):
+    for processed_item in processed_data.to_dict("records"):
         yield {
-            'text': text,
-            'tags': tag.split(','),
-            'meta': met
+            'text': " ".join([processed_item[col] for col in text_cols]),
+            'tags': processed_item["Sciencetags"].split(','),
+            'meta': {col: processed_item[col] for col in meta_cols}
         }
 
-def preprocess(input_path, output_path, text_cols):
+def preprocess(input_path, output_path, text_cols, meta_cols):
     data = pd.read_excel(input_path)
 
     tags = []
     with open(output_path, 'w') as f:
-        for chunk in yield_preprocess_data(data, text_cols=text_cols):
+        for chunk in yield_preprocess_data(data, text_cols, meta_cols):
             f.write(json.dumps(chunk))
             f.write('\n')
             tags.append(chunk['tags'])
@@ -118,9 +70,10 @@ if __name__ == '__main__':
     argparser.add_argument('--input', type=Path, help="path to raw Excel file with tagged or untagged grant data")
     argparser.add_argument('--output', type=Path, help="path to JSONL output file that will be generated")
     argparser.add_argument('--text_cols', type=str, default="Title,Synopsis", help="comma delimited column names to concatenate to text")
+    argparser.add_argument('--meta_cols', type=str, default="Grant_ID,Title", help="comma delimited column names to include in the meta")
     argparser.add_argument('--config', type=Path, help="path to config file that defines the arguments")
     args = argparser.parse_args()
-    print(args.config)
+
     if args.config:
         cfg = ConfigParser(allow_no_value=True)
         cfg.read(args.config)
@@ -128,13 +81,16 @@ if __name__ == '__main__':
         input_path = cfg["preprocess"]["input"]
         output_path = cfg["preprocess"]["output"]
         text_cols = cfg["preprocess"]["text_cols"]
+        meta_cols = cfg["preprocess"].get("meta_cols", "Grant_ID,Title")
     else:
         input_path = args.input
         output_path = args.output
-        text_cols = args.text_cols or "Title,Synopsis"
+        text_cols = args.text_cols
+        meta_cols = args.meta_cols
 
     text_cols = text_cols.split(",")
+    meta_cols = meta_cols.split(",")
     if os.path.exists(output_path):
         print(f"{output_path} exists. Remove if you want to rerun.")
     else:
-        preprocess(input_path, output_path, text_cols)
+        preprocess(input_path, output_path, text_cols, meta_cols)

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -183,7 +183,7 @@ def train_and_evaluate(
         parameters=None, model_path=None, test_data_path=None,
         online_learning=False, nb_epochs=5,
         from_same_distribution=False, threshold=None,
-        y_batch_size=None, verbose=True):
+        y_batch_size=None, data_format="JSONL", verbose=True):
 
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.load(f)
@@ -223,7 +223,8 @@ def train_and_evaluate(
             train_data_path=train_data_path,
             test_data_path=test_data_path,
             label_binarizer=label_binarizer,
-            from_same_distribution=from_same_distribution
+            from_same_distribution=from_same_distribution,
+            data_format=data_format
         )
         if y_batch_size:
             vectorizer = model.steps[0][1]
@@ -308,6 +309,7 @@ if __name__ == "__main__":
     argparser.add_argument('-f', '--from_same_distribution', type=strtobool, default=False, help="whether train and test contain the same examples but differ in other ways, important when loading train and test parts of datasets")
     argparser.add_argument('--threshold', type=float, default=None, help="threhsold to assign a tag")
     argparser.add_argument('--y_batch_size', type=int, default=None, help="batch size for Y in cases where Y large. defaults to None i.e. no batching of Y")
+    argparser.add_argument('--data_format', type=str, default="JSONL", help="format that will be used when loading the data. One of JSONL,DataFrame")
     args = argparser.parse_args()
 
     if args.config:
@@ -329,6 +331,7 @@ if __name__ == "__main__":
         y_batch_size = cfg["model"].get("y_batch_size")
         if y_batch_size:
             y_batch_size = int(y_batch_size)
+        data_format = cfg["data"].get("data_format", "JSONL")
     else:
         data_path = args.data
         label_binarizer_path = args.label_binarizer
@@ -341,6 +344,7 @@ if __name__ == "__main__":
         from_same_distribution = args.from_same_distribution
         threshold= args.threshold
         y_batch_size = args.y_batch_size
+        data_format = args.data_format
 
     if os.path.exists(model_path):
         print(f"{model_path} exists. Remove if you want to rerun.")
@@ -356,5 +360,6 @@ if __name__ == "__main__":
             nb_epochs=nb_epochs,
             from_same_distribution=from_same_distribution,
             threshold=threshold,
-            y_batch_size=y_batch_size
+            y_batch_size=y_batch_size,
+            data_format=data_format
         )

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -337,7 +337,7 @@ if __name__ == "__main__":
     argparser.add_argument('-f', '--from_same_distribution', type=strtobool, default=False, help="whether train and test contain the same examples but differ in other ways, important when loading train and test parts of datasets")
     argparser.add_argument('--threshold', type=float, default=None, help="threhsold to assign a tag")
     argparser.add_argument('--y_batch_size', type=int, default=None, help="batch size for Y in cases where Y large. defaults to None i.e. no batching of Y")
-    argparser.add_argument('--x_format', type=str, default="List", help="format that will be used when loading the data. One of JSONL,DataFrame")
+    argparser.add_argument('--x_format', type=str, default="List", help="format that will be used when loading the data. One of List,DataFrame")
     args = argparser.parse_args()
 
     if args.config:

--- a/grants_tagger/utils.py
+++ b/grants_tagger/utils.py
@@ -7,7 +7,7 @@ from sklearn.metrics import f1_score
 import pandas as pd
 import numpy as np
 
-def load_data(data_path, label_binarizer=None):
+def load_data(data_path, label_binarizer=None, X_format="List"):
     """Load data from the dataset."""
     print("Loading data...")
 
@@ -25,15 +25,22 @@ def load_data(data_path, label_binarizer=None):
     if label_binarizer:
         tags = label_binarizer.transform(tags)
 
+    if X_format == "DataFrame":
+        X = pd.DataFrame(meta)
+        X["text"] = texts
+        return X, tags, meta
+
     return texts, tags, meta
+        
 
 def load_train_test_data(
         train_data_path, label_binarizer,
-        test_data_path=None, from_same_distribution=False):
+        test_data_path=None, from_same_distribution=False,
+        X_format="List"):
 
     if test_data_path:
-        X_train, Y_train, _ = load_data(train_data_path, label_binarizer)
-        X_test, Y_test, _ = load_data(test_data_path, label_binarizer)
+        X_train, Y_train, _ = load_data(train_data_path, label_binarizer, X_format)
+        X_test, Y_test, _ = load_data(test_data_path, label_binarizer, X_format)
 
         if from_same_distribution:
             X_train, _, Y_train, _ = train_test_split(
@@ -43,7 +50,7 @@ def load_train_test_data(
                 X_test, Y_test, random_state=42
             )
     else:
-        X, Y, _ = load_data(train_data_path, label_binarizer)
+        X, Y, _ = load_data(train_data_path, label_binarizer, X_format)
         X_train, X_test, Y_train, Y_test = train_test_split(
             X, Y, random_state=42
         )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         'pandas',
         'xlrd',
-        'scikit-learn==0.21.3',
+        'scikit-learn==0.23.2',
         'nltk',
         'matplotlib',
         'wellcomeml[deep-learning]==2020.9.0',

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -7,6 +7,10 @@ def test_multiple_tags():
     data = pd.DataFrame({
         'Title': ['A', 'A'],
         'Synopsis': ['a', 'a'],
+        'Lay Summary': ['b', 'b'],
+        'Qu.': ['c', 'c'],
+        'Scheme': ['d', 'd'],
+        'Team': ['e', 'e'],
         'Grant_ID': [1, 1],
         'Sciencetags': ['T1', 'T2']
     })
@@ -21,6 +25,10 @@ def test_multiple_grants():
     data = pd.DataFrame({
         'Title': ['A', 'B'],
         'Synopsis': ['a', 'b'],
+        'Lay Summary': ['b', 'b'],
+        'Qu.': ['c', 'c'],
+        'Scheme': ['d', 'd'],
+        'Team': ['e', 'e'],
         'Grant_ID': [1, 2],
         'Sciencetags': ['T1', 'T2']
     })
@@ -36,6 +44,10 @@ def test_duplicate_grants():
     data = pd.DataFrame({
         'Title': ['A', 'A'],
         'Synopsis': ['a', 'a'],
+        'Lay Summary': ['b', 'b'],
+        'Qu.': ['c', 'c'],
+        'Scheme': ['d', 'd'],
+        'Team': ['e', 'e'],
         'Grant_ID': [1, 1],
         'Sciencetags': ['T1', 'T1']
     })
@@ -50,6 +62,10 @@ def test_missing_synopsis():
     data = pd.DataFrame({
         'Title': ['A', 'B'],
         'Synopsis': ['a', np.NaN],
+        'Lay Summary': ['b', 'b'],
+        'Qu.': ['c', 'c'],
+        'Scheme': ['d', 'd'],
+        'Team': ['e', 'e'],
         'Grant_ID': [1, 2],
         'Sciencetags': ['T1', 'T2']
     })


### PR DESCRIPTION
This PR goal was to introduce an experiment on running tagging with additional meta columns such as Team and Scheme. This is so that we can evaluate the effects that those variables can have but also to prepare the ground for using additinal fields something also relevant for mesh tagging

To do so I had to
* change preprocessing to include those fields, this was a good opportunity to greatly simplify that module
* represent X as a DataFrame that not only contains list of texts but also those additional fields
* create approaches that combine text with meta features in sklearn