### PR TITLE
Add tune threshold functionality

### DIFF
--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -17,7 +17,7 @@ from grants_tagger.predict_mesh import predict_tfidf_svm, predict_cnn
 from grants_tagger.predict import predict_proba_ensemble_tfidf_svm_bert, load_model
 
 
-def predict(X_test, model_path, nb_labels=None, threshold=None, return_probabilities=False):
+def predict(X_test, model_path, nb_labels=None, threshold=0.5, return_probabilities=False):
     # comma indicates ensemble of more than one models
     if "," in model_path:
         model_paths = model_path.split(",")

--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -17,20 +17,26 @@ from grants_tagger.predict_mesh import predict_tfidf_svm, predict_cnn
 from grants_tagger.predict import predict_proba_ensemble_tfidf_svm_bert, load_model
 
 
-def predict(X_test, model_path, nb_labels, threshold):
+def predict(X_test, model_path, nb_labels=None, threshold=None, return_probabilities=False):
     # comma indicates ensemble of more than one models
     if "," in model_path:
         model_paths = model_path.split(",")
         Y_pred_proba = predict_proba_ensemble_tfidf_svm_bert(X_test, model_paths)
-        Y_pred = Y_pred_proba > threshold
+        if return_probabilities:
+            Y_pred = Y_pred_proba
+        else:
+            Y_pred = Y_pred_proba > threshold
     elif "disease_mesh_cnn" in model_path:
-        Y_pred = predict_cnn(X_test, model_path, threshold)
+        Y_pred = predict_cnn(X_test, model_path, threshold, return_probabilities)
     elif "disease_mesh_tfidf" in model_path:
-        Y_pred = predict_tfidf_svm(X_test, model_path, nb_labels, threshold)
+        Y_pred = predict_tfidf_svm(X_test, model_path, nb_labels, threshold, return_probabilities)
     else:
         model = load_model(model_path)
         Y_pred_proba = model.predict_proba(X_test)
-        Y_pred = Y_pred_proba > threshold
+        if return_probabilities:
+            Y_pred = Y_pred_proba
+        else:
+            Y_pred = Y_pred_proba > threshold
     return Y_pred
 
 

--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -7,7 +7,7 @@ import pickle
 
 from wellcomeml.ml import CNNClassifier
 from numpy import hstack, vstack
-from scipy.sparse import hstack as sparse_hstack
+from scipy.sparse import hstack as sparse_hstack, csr_matrix
 
 
 def predict_tfidf_svm(X, model_path, nb_labels, threshold=0.5,
@@ -23,6 +23,9 @@ def predict_tfidf_svm(X, model_path, nb_labels, threshold=0.5,
         X_vec = vectorizer.transform(X)
         if return_probabilities:
             Y_pred_i = classifier.predict_proba(X_vec)
+        elif threshold != 0.5:
+            Y_pred_i = classifier.predict_proba(X_vec)
+            Y_pred_i = csr_matrix(Y_pred_i > threshold)
         else:
             Y_pred_i = classifier.predict(X_vec)
         Y_pred.append(Y_pred_i)

--- a/grants_tagger/tune_threshold.py
+++ b/grants_tagger/tune_threshold.py
@@ -60,7 +60,7 @@ def argmaxf1(thresholds, Y_test, Y_pred_proba, label_i, nb_thresholds, iteration
     return optimal_threshold_i, max_f1
 
 
-def optimise_threshold(Y_test, Y_pred_proba, nb_thresholds, init_threshold=None):
+def optimise_threshold(Y_test, Y_pred_proba, nb_thresholds=None, init_threshold=None):
     if init_threshold:
         optimal_thresholds = [init_threshold] * Y_pred_proba.shape[1]
     else:

--- a/grants_tagger/tune_threshold.py
+++ b/grants_tagger/tune_threshold.py
@@ -19,7 +19,7 @@ from scipy.sparse import csr_matrix, issparse
 import numpy as np
 
 from grants_tagger.evaluate_model import predict
-from grants_tagger.utils import load_data
+from grants_tagger.utils import load_train_test_data
 
 
 def argmaxf1(thresholds, Y_test, Y_pred_proba, label_i, nb_thresholds, iterations):
@@ -94,8 +94,7 @@ def tune_threshold(data_path, model_path, label_binarizer_path, thresholds_path,
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
 
-    X, Y, _ = load_data(data_path, label_binarizer)
-    _, X_test, _, Y_test = train_test_split(X, Y, random_state=42)    
+    _, X_test, _, Y_test = load_train_test_data(data_path, label_binarizer)
 
     if not sample_size:
         sample_size = Y_test.shape[0]

--- a/grants_tagger/tune_threshold.py
+++ b/grants_tagger/tune_threshold.py
@@ -35,7 +35,7 @@ def argmaxf1(thresholds, Y_test, Y_pred_proba, label_i, nb_thresholds, iteration
     if nb_thresholds:
         candidate_thresholds_i = [t/nb_thresholds for t in range(1, nb_thresholds)]
     else:
-        candidate_thresholds_i = Y_pred_proba[:, label_i]
+        candidate_thresholds_i = np.unique(Y_pred_proba[:, label_i])
     for candidate_threshold_i in candidate_thresholds_i:
         # no need to check in first iteration where first calibration happens
         if iterations >= 1:

--- a/grants_tagger/tune_threshold.py
+++ b/grants_tagger/tune_threshold.py
@@ -1,0 +1,134 @@
+"""
+Tune threshold of multilabel classifier to maximise f1
+
+based on paper "Threshold optimisation for multi-label classifiers"
+by Pillai https://doi.org/10.1016/j.patcog.2013.01.012
+
+There are currently two deviations from the paper
+* fixed number of thresholds to be tried instead of all values from Y_pred_proba for efficiency
+* initialisation of thresholds with 0.5 which seems to help convergence in large number of labels
+"""
+from pathlib import Path
+import argparse
+import pickle
+import random
+
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import f1_score, multilabel_confusion_matrix, confusion_matrix
+from scipy.sparse import csr_matrix, issparse
+import numpy as np
+
+from grants_tagger.evaluate_model import predict
+from grants_tagger.utils import load_data
+
+
+def argmaxf1(thresholds, Y_test, Y_pred_proba, label_i, nb_thresholds, iterations):
+    candidate_thresholds = thresholds.copy()
+    current_threshold_i = thresholds[label_i]
+    max_f1 = 0
+    optimal_threshold_i = current_threshold_i
+
+    Y_pred = Y_pred_proba > candidate_thresholds
+    Y_pred = csr_matrix(Y_pred)
+    cm = multilabel_confusion_matrix(Y_test, Y_pred)
+
+    if nb_thresholds:
+        candidate_thresholds_i = [t/nb_thresholds for t in range(1, nb_thresholds)]
+    else:
+        candidate_thresholds_i = Y_pred_proba[:, label_i]
+    for candidate_threshold_i in candidate_thresholds_i:
+        # no need to check in first iteration where first calibration happens
+        if iterations >= 1:
+            # paper proves that smaller thresholds will not produce better f1
+            if candidate_threshold_i < current_threshold_i:
+                continue
+        candidate_thresholds[label_i] = candidate_threshold_i
+
+        y_pred = Y_pred_proba[:, label_i] > candidate_threshold_i
+        y_test = Y_test[:, label_i]
+        if issparse(y_test):
+            y_test = np.array(y_test.todense()).ravel()
+        cm_i = confusion_matrix(y_test, y_pred)
+        cm[label_i, :, :] = cm_i
+
+        tn, fp, fn, tp = cm.sum(axis=0).ravel()
+        f1 = tp / (tp + (fp+fn) / 2)
+
+        if f1 > max_f1:
+            max_f1 = f1
+            optimal_threshold_i = candidate_threshold_i
+    return optimal_threshold_i, max_f1
+
+
+def optimise_threshold(Y_test, Y_pred_proba, nb_thresholds, init_threshold=None):
+    if init_threshold:
+        optimal_thresholds = [init_threshold] * Y_pred_proba.shape[1]
+    else:
+        # start with lowest posible threshold per label
+        optimal_thresholds = Y_pred_proba.min(axis=0).ravel()
+    updated = True
+
+    Y_pred = Y_pred_proba > optimal_thresholds
+    optimal_f1 = f1_score(Y_test, Y_pred, average="micro")
+    print("---Starting f1---")
+    print(f"{optimal_f1:.3f}\n")
+    
+    iterations = 0
+    while updated:
+        print(f"---Iteration {iterations}---")
+        updated = False
+        for label_i in range(Y_test.shape[1]):
+            # find threshold for label that maximises overall f1
+            optimal_threshold_i, max_f1 = argmaxf1(optimal_thresholds, Y_test, Y_pred_proba, label_i, nb_thresholds, iterations)
+            if max_f1 > optimal_f1:
+                print(f"Label: {label_i:4d} - f1: {max_f1:.6f} - Th: {optimal_threshold_i:.3f}")
+                optimal_f1 = max_f1
+                optimal_thresholds[label_i] = optimal_threshold_i
+                updated = True
+        iterations += 1
+
+    return optimal_thresholds
+
+
+def tune_threshold(data_path, model_path, label_binarizer_path, thresholds_path, sample_size=None, nb_thresholds=None, init_threshold=None):
+    with open(label_binarizer_path, "rb") as f:
+        label_binarizer = pickle.loads(f.read())
+
+    X, Y, _ = load_data(data_path, label_binarizer)
+    _, X_test, _, Y_test = train_test_split(X, Y, random_state=42)    
+
+    if not sample_size:
+        sample_size = Y_test.shape[0]
+
+    sample_indices = random.sample(list(range(Y_test.shape[0])), sample_size)
+
+    X_test = np.array(X_test)
+    X_test_sample = X_test[sample_indices]
+    Y_test_sample = Y_test[sample_indices, :]
+
+    Y_pred_proba = predict(X_test_sample, model_path, return_probabilities=True)
+
+    optimal_thresholds = optimise_threshold(Y_test_sample, Y_pred_proba, nb_thresholds, init_threshold)
+
+    Y_pred = predict(X_test, model_path, threshold=optimal_thresholds)
+    
+    optimal_f1 = f1_score(Y_test, Y_pred, average="micro")
+    print("---Optimal f1---")
+    print(f"{optimal_f1:.3f}")
+
+    with open(thresholds_path, "wb") as f:
+        f.write(pickle.dumps(optimal_thresholds))
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser(description=__doc__.strip())
+    argparser.add_argument("--data_path", type=Path, help="path to data in jsonl to train and test model", required=True)
+    argparser.add_argument("--model_path", type=str, help="path to model or comma separated path to multiple models", required=True)
+    argparser.add_argument("--label_binarizer_path", type=Path, help="path to label binarizer", required=True)
+    argparser.add_argument("--thresholds_path", type=Path, help="path to save threshold values", required=True)
+    argparser.add_argument("--sample_size", type=int, help="sample size of text data to use for tuning")
+    argparser.add_argument("--nb_thresholds", type=int, help="number of thresholds to be tried divided evenly between 0 and 1")
+    argparser.add_argument("--init_threshold", type=float, help="value to initialise threshold values")
+    args = argparser.parse_args()
+
+    tune_threshold(args.data_path, args.model_path, args.label_binarizer_path, args.thresholds_path,
+                   args.sample_size, args.nb_thresholds, args.init_threshold)

--- a/tests/test_predict_mesh.py
+++ b/tests/test_predict_mesh.py
@@ -9,7 +9,7 @@ from sklearn.multiclass import OneVsRestClassifier
 from sklearn.linear_model import SGDClassifier
 from wellcomeml.ml import CNNClassifier, KerasVectorizer
 
-from grants_tagger.predict_mesh import predict_mesh_tags
+from grants_tagger.predict_mesh import predict_mesh_tags, predict_tfidf_svm
 
 X = [
     "all",
@@ -78,6 +78,22 @@ def test_predict_mesh_tfidf_svm():
 
         tags = predict_mesh_tags(X, model_path, label_binarizer_path)
         assert len(tags) == 5
+
+
+def test_predict_mesh_tfidf_svm_threshold():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        model_path = f"{tmp_dir}/tfidf_model/"
+        os.mkdir(model_path)
+        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
+        train_test_tfidf_svm_model(model_path, label_binarizer_path)
+
+        nb_examples = 5
+        nb_labels = 5000
+        Y = predict_tfidf_svm(X, model_path, nb_labels, threshold=0, return_probabilities=False)
+        assert Y.sum() == nb_labels * nb_examples # all 1
+
+        Y = predict_tfidf_svm(X, model_path, nb_labels, threshold=1, return_probabilities=False)
+        assert Y.sum() == 0 # all 0
 
 
 def test_predict_mesh_cnn():

--- a/tests/test_tune_threshold.py
+++ b/tests/test_tune_threshold.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from grants_tagger.tune_threshold import optimise_threshold
+
+
+def test_random_Y():
+    Y_test = np.random.rand(2, 3) > 0.5
+    Y_pred_proba = np.random.rand(2, 3)
+
+    thresholds = optimise_threshold(Y_test, Y_pred_proba)
+    assert len(thresholds) == 3
+
+
+def test_ones_Y():
+    Y_test = np.ones((2, 3))
+    Y_pred_proba = np.array([
+        [0.3, 0.5, 0.7],
+        [0.1, 0.8, 0.2]
+    ])
+    optimal_thresholds = optimise_threshold(Y_test, Y_pred_proba)
+    expected_thresholds = [0.1, 0.5, 0.2]
+    assert np.array_equal(optimal_thresholds, expected_thresholds)
+
+
+def test_realistic_Y():
+    Y_test = np.array([
+        [0, 0, 1],
+        [1, 0, 0],
+        [0, 1, 0]
+    ])
+    Y_pred_proba = np.array([
+        [0.3, 0.5, 0.7],
+        [0.6, 0.7, 0.3],
+        [0.1, 0.8, 0.2]
+    ])
+    optimal_thresholds = optimise_threshold(Y_test, Y_pred_proba)
+    expected_thresholds = [0.3, 0.7, 0.3]
+    assert np.array_equal(optimal_thresholds, expected_thresholds)


### PR DESCRIPTION
This PR implements tuning threshold for our tagger inspired from the paper https://doi.org/10.1016/j.patcog.2013.01.012 but modified to be efficient for MeSH. Modifications are:

- Tune threshold on a sample of the test set
- Try a fixed number of thresholds in the continuous range 0 to 1. For example if we want to try 5 thresholds they would be 0 0.2 0.4 0.6 0.8
- Init threshold value instead of starting from an unnecessarily bad init value which requires more iterations