### PR TITLE
Evaluate model

### DIFF
--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -17,7 +17,7 @@ from grants_tagger.utils import load_data
 # TODO: Save tfidf as vectorizer in disease_mesh
 # TODO: Use Pipeline or class to explore predict for disease_mesh
 
-def load_model(model_path, threshold=0.5):
+def load_model(model_path):
     if 'pkl' in model_path[-4:]:
         with open(model_path, "rb") as f:
             model = pickle.loads(f.read())
@@ -37,13 +37,9 @@ def evaluate_model(model_path, data_path, label_binarizer_path, threshold):
 
     # comma indicates ensemble of more than one models
     if "," in model_path:        
-        models = []
-        for model_path_ in model_path.split(","):
-            model = load_model(model_path_, threshold)
-            models.append(model)
-
         Y_pred_probs = np.zeros(Y_test.shape)
-        for model in models:
+        for model_path_ in model_path.split(","):
+            model = load_model(model_path_)
             Y_pred_probs_model = model.predict_proba(X_test)
             Y_pred_probs += Y_pred_probs_model
 

--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -20,16 +20,16 @@ from grants_tagger.predict import predict_proba_ensemble_tfidf_svm_bert, load_mo
 # TODO: Use Pipeline or class to explore predict for disease_mesh
 
 
-def predict(X_test, model_path, nb_labels, threshold=0.5):
+def predict(X_test, model_path, nb_labels, threshold):
     # comma indicates ensemble of more than one models
     if "," in model_path:
         model_paths = model_path.split(",")
         Y_pred_proba = predict_proba_ensemble_tfidf_svm_bert(X_test, model_paths)
         Y_pred = Y_pred_proba > float(threshold)
     elif "disease_mesh_cnn" in model_path:
-        Y_pred = predict_cnn(X_test, model_path, threshold)
+        Y_pred = predict_cnn(X_test, model_path, float(threshold))
     elif "disease_mesh_tfidf" in model_path:
-        Y_pred = predict_tfidf_svm(X_test, model_path, nb_labels, threshold)
+        Y_pred = predict_tfidf_svm(X_test, model_path, nb_labels, float(threshold))
     else:
         model = load_model(model_path) # no load_model
         Y_pred_proba = model.predict_proba(X_test)
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     argparser.add_argument("--models", type=str, help="comma separated paths to pretrained models")
     argparser.add_argument("--data", type=Path, help="path to data that was used for training")
     argparser.add_argument("--label_binarizer", type=Path, help="path to label binarizer")
-    argparser.add_argument("--threshold", type=str, help="threshold or comma separated thresholds used to assign tags")
+    argparser.add_argument("--threshold", type=str, default="0.5", help="threshold or comma separated thresholds used to assign tags")
     argparser.add_argument("--config", type=Path, help="path to config file that defines arguments")
     args = argparser.parse_args()
 

--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -16,9 +16,6 @@ from grants_tagger.utils import load_data
 from grants_tagger.predict_mesh import predict_tfidf_svm, predict_cnn
 from grants_tagger.predict import predict_proba_ensemble_tfidf_svm_bert, load_model
 
-# TODO: Save tfidf as vectorizer in disease_mesh
-# TODO: Use Pipeline or class to explore predict for disease_mesh
-
 
 def predict(X_test, model_path, nb_labels, threshold):
     # comma indicates ensemble of more than one models

--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -6,13 +6,13 @@ from configparser import ConfigParser
 from pathlib import Path
 import pickle
 
+from wellcomeml.ml import BertClassifier, CNNClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import f1_score, classification_report
 import numpy as np
 
-from wellcomeml.ml import BertClassifier, CNNClassifier
 from grants_tagger.utils import load_data
-
+from grants_tagger.predict_mesh import predict_proba_tfidf_svm, predict_proba_cnn
 
 # TODO: Save tfidf as vectorizer in disease_mesh
 # TODO: Use Pipeline or class to explore predict for disease_mesh
@@ -37,35 +37,19 @@ def evaluate_model(model_path, data_path, label_binarizer_path, threshold):
 
     # comma indicates ensemble of more than one models
     if "," in model_path:        
-        Y_pred_probs = np.zeros(Y_test.shape)
+        Y_pred_proba = np.zeros(Y_test.shape)
         for model_path_ in model_path.split(","):
             model = load_model(model_path_)
-            Y_pred_probs_model = model.predict_proba(X_test)
-            Y_pred_probs += Y_pred_probs_model
+            Y_pred_proba_model = model.predict_proba(X_test)
+            Y_pred_proba += Y_pred_proba_model
 
-        Y_pred_probs /= len(models)
-        Y_pred = Y_pred_probs > threshold
+        Y_pred_proba /= len(models)
     elif "disease_mesh_cnn" in model_path:
-        with open(f"{model_path}/vectorizer.pkl", "rb") as f:
-            vectorizer = pickle.loads(f.read())
-        classifier = CNNClassifier(sparse_y=True, threshold=threshold)
-        classifier.load(model_path)
-        X_test_vec = vectorizer.transform(X_test)
-        Y_pred = classifier.predict(X_test_vec)
+        Y_pred_proba = predict_proba_cnn(X_test, model_path)
     elif "disease_mesh_tfidf" in model_path:
-        with open(f"{model_path}/tfidf.pkl", "rb") as f:
-            vectorizer = pickle.loads(f.read())
-
         nb_labels = len(label_binarizer.classes_)
-        Y_pred_proba = []
-        for tag_i in range(0, nb_labels, y_batch_size):
-            with open(f"{model_path}/{tag_i}.pkl", "rb") as f:
-                classifier = pickle.loads(f.read())
-            X_vec = vectorizer.transform(X_test)
-            Y_pred_i = classifier.predict_proba(X_vec)
-            Y_pred_proba.append(Y_pred_i)
-        Y_pred_proba = hstack(Y_pred_proba)
-        Y_pred = Y_pred_proba > threshold
+        Y_pred_proba = predict_proba_tfidf_svm(X_test, model_path, nb_labels)
+    Y_pred = Y_pred_proba > threshold
 
     print(classification_report(Y_test, Y_pred))
  

--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -49,10 +49,10 @@ def evaluate_model(model_path, data_path, label_binarizer_path, threshold):
         results = []
         for threshold_ in threshold:
             Y_pred = predict(X_test, model_path, nb_labels, threshold_)
-            p = round(precision_score(Y_test, Y_pred, average='micro'), 2)
-            r = round(recall_score(Y_test, Y_pred, average='micro'), 2)
-            f1 = round(f1_score(Y_test, Y_pred, average='micro'), 2)
-            results.append((threshold_, p, r, f1))
+            p = precision_score(Y_test, Y_pred, average='micro')
+            r = recall_score(Y_test, Y_pred, average='micro')
+            f1 = f1_score(Y_test, Y_pred, average='micro')
+            results.append((threshold_, f"{p:.2f}", f"{r:.2f}", f"{f1:.2f}"))
         header = ["Threshold", "P", "R", "F1"]
         print(table(results, header, divider=True))
     else:
@@ -82,5 +82,7 @@ if __name__ == '__main__':
         label_binarizer = args.label_binarizer
         threshold = args.threshold
 
-    threshold = threshold.split(",") if "," in threshold else threshold
+    # comma indicates multiple threshold to evaluate against
+    if "," in threshold:
+        threshold = threshold.split(",")
     evaluate_model(models, data, label_binarizer, threshold)

--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from grants_tagger.utils import load_data
 from grants_tagger.predict_mesh import predict_tfidf_svm, predict_cnn
-from grants_tagger.predict import predict_proba_ensemble_tfidf_svm_bert
+from grants_tagger.predict import predict_proba_ensemble_tfidf_svm_bert, load_model
 
 # TODO: Save tfidf as vectorizer in disease_mesh
 # TODO: Use Pipeline or class to explore predict for disease_mesh

--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -39,12 +39,13 @@ def evaluate_model(model_path, data_path, label_binarizer_path, threshold):
     # comma indicates ensemble of more than one models
     if "," in model_path:        
         Y_pred_proba = np.zeros(Y_test.shape)
-        for model_path_ in model_path.split(","):
+        model_paths = model_path.split(",")
+        for model_path_ in model_paths:
             model = load_model(model_path_)
             Y_pred_proba_model = model.predict_proba(X_test)
             Y_pred_proba += Y_pred_proba_model
 
-        Y_pred_proba /= len(models)
+        Y_pred_proba /= len(model_paths)
     elif "disease_mesh_cnn" in model_path:
         Y_pred_proba = predict_proba_cnn(X_test, model_path)
     elif "disease_mesh_tfidf" in model_path:

--- a/grants_tagger/predict.py
+++ b/grants_tagger/predict.py
@@ -21,7 +21,7 @@ DEFAULT_LABELBINARIZER_PATH = os.path.join(FILEPATH, '../models/label_binarizer.
 
 
 def load_model(model_path):
-    if 'pkl' in model_path[-4:]:
+    if model_path.endswith('.pkl'):
         with open(model_path, "rb") as f:
             model = pickle.loads(f.read())
             return model

--- a/grants_tagger/predict.py
+++ b/grants_tagger/predict.py
@@ -39,7 +39,7 @@ def predict_proba_ensemble_tfidf_svm_bert(X, model_paths):
         Y_pred_proba_model = model.predict_proba(X)
         Y_pred_proba.append(Y_pred_proba_model)
 
-    Y_pred_proba = np.sum(Y_pred_proba) / len(model_paths)
+    Y_pred_proba = np.array(Y_pred_proba).sum(axis=0) / len(model_paths)
     return Y_pred_proba
 
 

--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -11,7 +11,7 @@ from scipy.sparse import hstack as sparse_hstack
 
 
 def predict_tfidf_svm(X, model_path, nb_labels, threshold=0.5,
-                      probability=True, y_batch_size=512):
+                      return_probabilities=True, y_batch_size=512):
     # TODO: generalise tfidf to vectorizer.pkl
     with open(f"{model_path}/tfidf.pkl", "rb") as f:
         vectorizer = pickle.loads(f.read())
@@ -21,13 +21,13 @@ def predict_tfidf_svm(X, model_path, nb_labels, threshold=0.5,
         with open(f"{model_path}/{tag_i}.pkl", "rb") as f:
             classifier = pickle.loads(f.read())
         X_vec = vectorizer.transform(X)
-        if probability:
+        if return_probabilities:
             Y_pred_i = classifier.predict_proba(X_vec)
         else:
             Y_pred_i = classifier.predict(X_vec)
         Y_pred.append(Y_pred_i)
 
-    if probability:
+    if return_probabilities:
         Y_pred = hstack(Y_pred)
     else:
         Y_pred = sparse_hstack(Y_pred)
@@ -35,7 +35,7 @@ def predict_tfidf_svm(X, model_path, nb_labels, threshold=0.5,
 
 
 def predict_cnn(X, model_path, threshold=0.5,
-                probability=False, x_batch_size=512):
+                return_probabilities=False, x_batch_size=512):
     with open(f"{model_path}/vectorizer.pkl", "rb") as f:
         vectorizer = pickle.loads(f.read())
     model = CNNClassifier(
@@ -44,7 +44,7 @@ def predict_cnn(X, model_path, threshold=0.5,
     model.load(model_path)
 
     X_vec = vectorizer.transform(X)
-    if probability:
+    if return_probabilities:
         Y_pred_proba = []
         for i in range(0, X_vec.shape[0], x_batch_size):
             Y_pred_proba_batch = model.predict_proba(X_vec[i:i+x_batch_size])
@@ -65,9 +65,9 @@ def predict_mesh_tags(X, model_path, label_binarizer_path,
     nb_labels = len(label_binarizer.classes_)
 
     if "tfidf" in str(model_path):
-        Y_pred_proba = predict_tfidf_svm(X, model_path, nb_labels, probability=True)
+        Y_pred_proba = predict_tfidf_svm(X, model_path, nb_labels, return_probabilities=True)
     elif "cnn" in str(model_path):
-        Y_pred_proba = predict_cnn(X, model_path, probability=True)
+        Y_pred_proba = predict_cnn(X, model_path, return_probabilities=True)
     else:
         raise NotImplementedError
 

--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -6,28 +6,45 @@ for making a prediction
 import pickle
 import os
 
-from numpy import hstack
+from wellcomeml.ml import CNNClassifier
+from numpy import hstack, vstack
+import numpy as np
 
 
 def predict_mesh_tags(X, model_path, label_binarizer_path,
                       probabilities=False, threshold=0.5,
                       y_batch_size=512):
-    # TODO: generalise tfidf to vectorizer.pkl
-    with open(f"{model_path}/tfidf.pkl", "rb") as f:
-        vectorizer = pickle.loads(f.read())
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
+    if "tfidf" in str(model_path):
+        # TODO: generalise tfidf to vectorizer.pkl
+        with open(f"{model_path}/tfidf.pkl", "rb") as f:
+            vectorizer = pickle.loads(f.read())
 
-    nb_labels = len(label_binarizer.classes_)
-    Y_pred_proba = []
-    for tag_i in range(0, nb_labels, y_batch_size):
-        with open(f"{model_path}/{tag_i}.pkl", "rb") as f:
-            classifier = pickle.loads(f.read())
+        nb_labels = len(label_binarizer.classes_)
+        Y_pred_proba = []
+        for tag_i in range(0, nb_labels, y_batch_size):
+            with open(f"{model_path}/{tag_i}.pkl", "rb") as f:
+                classifier = pickle.loads(f.read())
+            X_vec = vectorizer.transform(X)
+            Y_pred_i = classifier.predict_proba(X_vec)
+            Y_pred_proba.append(Y_pred_i)
+        Y_pred_proba = hstack(Y_pred_proba)
+    elif "cnn" in str(model_path):
+        with open(f"{model_path}/vectorizer.pkl", "rb") as f:
+            vectorizer = pickle.loads(f.read())
+        model = CNNClassifier(sparse_y=True)
+        model.load(model_path)
+
         X_vec = vectorizer.transform(X)
-        Y_pred_i = classifier.predict_proba(X_vec)
-        Y_pred_proba.append(Y_pred_i)
-    Y_pred_proba = hstack(Y_pred_proba)
-    
+        Y_pred_proba = []
+        for i in range(0, X_vec.shape[0], 512):
+            Y_pred_proba_batch = model.predict_proba(X_vec[i:i+512])
+            Y_pred_proba.append(Y_pred_proba_batch)
+        Y_pred_proba = vstack(Y_pred_proba)
+    else:
+        raise NotImplementedError
+
     tags = []
     for y_pred_proba in Y_pred_proba:
         if probabilities:

--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -11,37 +11,46 @@ from numpy import hstack, vstack
 import numpy as np
 
 
+def predict_proba_tfidf_svm(X, model_path, nb_labels, y_batch_size=512):
+    # TODO: generalise tfidf to vectorizer.pkl
+    with open(f"{model_path}/tfidf.pkl", "rb") as f:
+        vectorizer = pickle.loads(f.read())
+
+    Y_pred_proba = []
+    for tag_i in range(0, nb_labels, y_batch_size):
+        with open(f"{model_path}/{tag_i}.pkl", "rb") as f:
+            classifier = pickle.loads(f.read())
+        X_vec = vectorizer.transform(X)
+        Y_pred_i = classifier.predict_proba(X_vec)
+        Y_pred_proba.append(Y_pred_i)
+    Y_pred_proba = hstack(Y_pred_proba)
+    return Y_pred_proba
+
+def predict_proba_cnn(X, model_path, x_batch_size=512):
+    with open(f"{model_path}/vectorizer.pkl", "rb") as f:
+        vectorizer = pickle.loads(f.read())
+    model = CNNClassifier(sparse_y=True)
+    model.load(model_path)
+
+    X_vec = vectorizer.transform(X)
+    Y_pred_proba = []
+    for i in range(0, X_vec.shape[0], x_batch_size):
+        Y_pred_proba_batch = model.predict_proba(X_vec[i:i+x_batch_size])
+        Y_pred_proba.append(Y_pred_proba_batch)
+    Y_pred_proba = vstack(Y_pred_proba)
+
 def predict_mesh_tags(X, model_path, label_binarizer_path,
                       probabilities=False, threshold=0.5,
                       y_batch_size=512):
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
+
+    nb_labels = len(label_binarizer.classes_)
+
     if "tfidf" in str(model_path):
-        # TODO: generalise tfidf to vectorizer.pkl
-        with open(f"{model_path}/tfidf.pkl", "rb") as f:
-            vectorizer = pickle.loads(f.read())
-
-        nb_labels = len(label_binarizer.classes_)
-        Y_pred_proba = []
-        for tag_i in range(0, nb_labels, y_batch_size):
-            with open(f"{model_path}/{tag_i}.pkl", "rb") as f:
-                classifier = pickle.loads(f.read())
-            X_vec = vectorizer.transform(X)
-            Y_pred_i = classifier.predict_proba(X_vec)
-            Y_pred_proba.append(Y_pred_i)
-        Y_pred_proba = hstack(Y_pred_proba)
+        Y_pred_proba = predict_proba_tfidf_svm(X, model_path, nb_labels)
     elif "cnn" in str(model_path):
-        with open(f"{model_path}/vectorizer.pkl", "rb") as f:
-            vectorizer = pickle.loads(f.read())
-        model = CNNClassifier(sparse_y=True)
-        model.load(model_path)
-
-        X_vec = vectorizer.transform(X)
-        Y_pred_proba = []
-        for i in range(0, X_vec.shape[0], 512):
-            Y_pred_proba_batch = model.predict_proba(X_vec[i:i+512])
-            Y_pred_proba.append(Y_pred_proba_batch)
-        Y_pred_proba = vstack(Y_pred_proba)
+        Y_pred_proba = predict_proba_cnn(X, model_path)
     else:
         raise NotImplementedError
 

--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -35,10 +35,12 @@ def predict_tfidf_svm(X, model_path, nb_labels, threshold=0.5,
 
 
 def predict_cnn(X, model_path, threshold=0.5,
-                probability=True, x_batch_size=512):
+                probability=False, x_batch_size=512):
     with open(f"{model_path}/vectorizer.pkl", "rb") as f:
         vectorizer = pickle.loads(f.read())
-    model = CNNClassifier(sparse_y=True, threshold=threshold)
+    model = CNNClassifier(
+        sparse_y=True, threshold=threshold, batch_size=x_batch_size
+    )
     model.load(model_path)
 
     X_vec = vectorizer.transform(X)

--- a/grants_tagger/predict_mesh.py
+++ b/grants_tagger/predict_mesh.py
@@ -47,7 +47,7 @@ def predict_cnn(X, model_path, threshold=0.5,
     if probability:
         Y_pred_proba = []
         for i in range(0, X_vec.shape[0], x_batch_size):
-            Y_pred_proba_batch = model.predict(X_vec[i:i+x_batch_size])
+            Y_pred_proba_batch = model.predict_proba(X_vec[i:i+x_batch_size])
             Y_pred_proba.append(Y_pred_proba_batch)
         Y_pred_proba = vstack(Y_pred_proba)
         return Y_pred_proba

--- a/grants_tagger/tag_grants_with_mesh.py
+++ b/grants_tagger/tag_grants_with_mesh.py
@@ -42,10 +42,11 @@ def yield_tagged_grants(grants, tags):
         })
         yield tagged_grant
 
-def tag_grants_with_mesh(grants_path, tagged_grants_path, model_path, label_binarizer_path):
+def tag_grants_with_mesh(grants_path, tagged_grants_path, model_path, label_binarizer_path, threshold):
     grants = [g for g in yield_grants(grants_path)]
     grants_text = [grant['title'] + ' ' + grant['synopsis'] for grant in grants]
-    tags = predict_tags(grants_text, model_path=model_path, label_binarizer_path=label_binarizer_path)
+    tags = predict_tags(grants_text, model_path=model_path, label_binarizer_path=label_binarizer_path,
+                        threshold=threshold)
     
     with open(tagged_grants_path, 'w') as f_o:
         fieldnames = ["Grant ID", "Reference", "Grant No."]
@@ -64,6 +65,7 @@ if __name__ == '__main__':
     argparser.add_argument('--tagged_grants', type=Path, help="path to output the tagged grants")
     argparser.add_argument('--model_path', type=Path, default=DEFAULT_MODEL_PATH, help="path to a dir that contains the batched models")
     argparser.add_argument('--label_binarizer_path', type=Path, default=DEFAULT_LABEL_BINARIZER_PATH, help="path to mesh label binarizer")
+    argparser.add_argument('--threshold', type=float, default=0.5, help="threshold to assign tags")
     args = argparser.parse_args()
 
-    tag_grants_with_mesh(args.grants, args.tagged_grants, args.model_path, args.label_binarizer_path)
+    tag_grants_with_mesh(args.grants, args.tagged_grants, args.model_path, args.label_binarizer_path, args.threshold)

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -211,7 +211,8 @@ def train_and_evaluate(
         parameters=None, model_path=None, test_data_path=None,
         online_learning=False, nb_epochs=5,
         from_same_distribution=False, threshold=None,
-        y_batch_size=None, X_format="List", verbose=True):
+        y_batch_size=None, X_format="List",
+        test_size=0.25, verbose=True):
 
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.load(f)
@@ -252,7 +253,8 @@ def train_and_evaluate(
             test_data_path=test_data_path,
             label_binarizer=label_binarizer,
             from_same_distribution=from_same_distribution,
-            X_format=X_format
+            X_format=X_format,
+            test_size=test_size
         )
         if y_batch_size:
             vectorizer = model.steps[0][1]
@@ -338,6 +340,7 @@ if __name__ == "__main__":
     argparser.add_argument('--threshold', type=float, default=None, help="threhsold to assign a tag")
     argparser.add_argument('--y_batch_size', type=int, default=None, help="batch size for Y in cases where Y large. defaults to None i.e. no batching of Y")
     argparser.add_argument('--x_format', type=str, default="List", help="format that will be used when loading the data. One of List,DataFrame")
+    argparser.add_argument('--test_size', type=float, default=0.25, help="float or int indicating either percentage or absolute number of test examples")
     args = argparser.parse_args()
 
     if args.config:
@@ -360,6 +363,7 @@ if __name__ == "__main__":
         if y_batch_size:
             y_batch_size = int(y_batch_size)
         X_format = cfg["data"].get("x_format", "List")
+        test_size = float(cfg["data"].get("test_size", 0.25))
     else:
         data_path = args.data
         label_binarizer_path = args.label_binarizer
@@ -373,6 +377,7 @@ if __name__ == "__main__":
         threshold = args.threshold
         y_batch_size = args.y_batch_size
         X_format = args.x_format
+        test_size = args.test_size
 
     if os.path.exists(model_path):
         print(f"{model_path} exists. Remove if you want to rerun.")
@@ -389,5 +394,6 @@ if __name__ == "__main__":
             from_same_distribution=from_same_distribution,
             threshold=threshold,
             y_batch_size=y_batch_size,
-            X_format=X_format
+            X_format=X_format,
+            test_size=test_size
         )

--- a/grants_tagger/utils.py
+++ b/grants_tagger/utils.py
@@ -36,7 +36,7 @@ def load_data(data_path, label_binarizer=None, X_format="List"):
 def load_train_test_data(
         train_data_path, label_binarizer,
         test_data_path=None, from_same_distribution=False,
-        X_format="List"):
+        X_format="List", test_size=None):
 
     if test_data_path:
         X_train, Y_train, _ = load_data(train_data_path, label_binarizer, X_format)
@@ -52,7 +52,7 @@ def load_train_test_data(
     else:
         X, Y, _ = load_data(train_data_path, label_binarizer, X_format)
         X_train, X_test, Y_train, Y_test = train_test_split(
-            X, Y, random_state=42
+            X, Y, random_state=42, test_size=test_size
         )
            
     return X_train, X_test, Y_train, Y_test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scikit-multilearn
 arff
 python-dateutil<2.8.1,>=2.1
--e git+git://github.com/wellcometrust/WellcomeML.git@27b483df4df751fc2de894ca0a7441e5d2155c6b#egg=wellcomeml[deep-learning]
+-e git+git://github.com/wellcometrust/WellcomeML.git@c844f89f57544096a89defeeacd074d3041a9c7a#egg=wellcomeml[deep-learning]

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
         'matplotlib',
         'wellcomeml[deep-learning]==2020.9.0',
         'docutils==0.15',
-        'scipy==1.4.1'
+        'scipy==1.4.1',
+        'wasabi'
     ],
     tests_require=[
         'pytest',

--- a/tests/test_evaluate_model.py
+++ b/tests/test_evaluate_model.py
@@ -1,0 +1,87 @@
+from unittest.mock import patch
+import tempfile
+import pickle
+import json
+
+from sklearn.preprocessing import MultiLabelBinarizer
+import numpy as np
+
+from grants_tagger.evaluate_model import evaluate_model, predict
+
+
+X = [
+    "all",
+    "one two",
+    "two",
+    "four",
+    "twenty four"
+]
+Y = [
+    [str(i) for i in range(24)],
+    ["1", "2"],
+    ["2"],
+    ["4"],
+    ["24"]
+]
+
+
+def create_test_data(data_path):
+    with open(data_path, "w") as f:
+        for x, y in zip(X, Y):
+            item = json.dumps({"text": x, "tags": y, "meta": ""})
+            f.write(item+"\n")
+
+
+def test_evaluate_model():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
+        data_path = f"{tmp_dir}/data.jsonl"
+
+        label_binarizer = MultiLabelBinarizer()
+        label_binarizer.fit(Y)
+        with open(label_binarizer_path, "wb") as f:
+            f.write(pickle.dumps(label_binarizer))
+
+        create_test_data(data_path)
+
+        with patch('grants_tagger.evaluate_model.predict') as mock_predict:
+            Y_test = [["1"], ["2"]]
+            mock_predict.return_value = label_binarizer.transform(Y_test)
+
+            evaluate_model("model_path", data_path, label_binarizer_path, 0.5)
+
+
+def test_evaluate_model_multiple_thresholds():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
+        data_path = f"{tmp_dir}/data.jsonl"
+
+        label_binarizer = MultiLabelBinarizer()
+        label_binarizer.fit(Y)
+        with open(label_binarizer_path, "wb") as f:
+            f.write(pickle.dumps(label_binarizer))
+
+        create_test_data(data_path)
+
+        with patch('grants_tagger.evaluate_model.predict') as mock_predict:
+            Y_test = [["1"], ["2"]]
+            mock_predict.return_value = label_binarizer.transform(Y_test)
+
+            evaluate_model("model_path", data_path, label_binarizer_path, [0,1,0.5,0.9])
+
+
+def test_evaluate_model_predict_cnn():
+    with patch('grants_tagger.evaluate_model.predict_cnn') as mock_predict_cnn:
+        predict("X_test", "disease_mesh_cnn_model_path", "nb_labels", "threshold")
+        mock_predict_cnn.assert_called()
+
+def test_evaluate_model_predict_tfidf_svm():
+    with patch('grants_tagger.evaluate_model.predict_tfidf_svm') as mock_predict_tfidf_svm:
+        predict("X_test", "disease_mesh_tfidf_model_path", "nb_labels", "threshold")
+        mock_predict_tfidf_svm.assert_called()
+
+def test_evaluate_model_predict_ensemble():
+    with patch('grants_tagger.evaluate_model.predict_proba_ensemble_tfidf_svm_bert') as mock_predict_ensemble:
+        mock_predict_ensemble.return_value = np.random.randn(2, 24)
+        predict("X_test", "tfidf,bert_model_paths", "nb_labels", 0.5)
+        mock_predict_ensemble.assert_called()

--- a/tests/test_evaluate_model.py
+++ b/tests/test_evaluate_model.py
@@ -49,6 +49,7 @@ def test_evaluate_model():
             mock_predict.return_value = label_binarizer.transform(Y_test)
 
             evaluate_model("model_path", data_path, label_binarizer_path, 0.5)
+            mock_predict.assert_called()
 
 
 def test_evaluate_model_multiple_thresholds():
@@ -68,7 +69,7 @@ def test_evaluate_model_multiple_thresholds():
             mock_predict.return_value = label_binarizer.transform(Y_test)
 
             evaluate_model("model_path", data_path, label_binarizer_path, [0,1,0.5,0.9])
-
+            mock_predict.assert_called()
 
 def test_evaluate_model_predict_cnn():
     with patch('grants_tagger.evaluate_model.predict_cnn') as mock_predict_cnn:

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -49,7 +49,7 @@ def train_test_model(scibert_path, tfidf_svm_path, label_binarizer_path):
     scibert.fit(X, Y_vec)
     scibert.save(scibert_path)
 
-def test_predict_mesh():
+def test_predict():
     with tempfile.TemporaryDirectory() as tmp_dir:
         scibert_path = f"{tmp_dir}/model/"
         os.mkdir(scibert_path)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -51,7 +51,7 @@ def train_test_model(scibert_path, tfidf_svm_path, label_binarizer_path):
 
 def test_predict():
     with tempfile.TemporaryDirectory() as tmp_dir:
-        scibert_path = f"{tmp_dir}/model/"
+        scibert_path = f"{tmp_dir}/scibert/"
         os.mkdir(scibert_path)
         tfidf_svm_path = f"{tmp_dir}/tfidf_svm.pkl"
         label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"

--- a/tests/test_predict_mesh.py
+++ b/tests/test_predict_mesh.py
@@ -7,6 +7,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.preprocessing import MultiLabelBinarizer
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.linear_model import SGDClassifier
+from wellcomeml.ml import CNNClassifier, KerasVectorizer
 
 from grants_tagger.predict_mesh import predict_mesh_tags
 
@@ -25,7 +26,7 @@ Y = [
     ["1000"]
 ]
 
-def train_test_model(model_path, label_binarizer_path):
+def train_test_tfidf_svm_model(model_path, label_binarizer_path):
     tfidf = TfidfVectorizer()
     tfidf.fit(X)
     with open(f"{model_path}/tfidf.pkl", "wb") as f:
@@ -47,12 +48,44 @@ def train_test_model(model_path, label_binarizer_path):
         with open(f"{model_path}/{tag_i}.pkl", "wb") as f:
             f.write(pickle.dumps(model))
 
-def test_predict_mesh():
+def train_test_cnn_model(model_path, label_binarizer_path):
+    vectorizer = KerasVectorizer()
+    vectorizer.fit(X)
+    with open(f"{model_path}/vectorizer.pkl", "wb") as f:
+        f.write(pickle.dumps(vectorizer))
+
+    X_vec = vectorizer.transform(X)
+
+    label_binarizer = MultiLabelBinarizer()
+    label_binarizer.fit(Y)
+    with open(f"{label_binarizer_path}", "wb") as f:
+        f.write(pickle.dumps(label_binarizer))
+        f.seek(0)
+
+    Y_vec = label_binarizer.transform(Y)
+
+    model = CNNClassifier(multilabel=True)
+    model.fit(X_vec, Y_vec)
+    model.save(model_path)
+
+
+def test_predict_mesh_tfidf_svm():
     with tempfile.TemporaryDirectory() as tmp_dir:
-        model_path = f"{tmp_dir}/model/"
+        model_path = f"{tmp_dir}/tfidf_model/"
         os.mkdir(model_path)
         label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
-        train_test_model(model_path, label_binarizer_path)
+        train_test_tfidf_svm_model(model_path, label_binarizer_path)
+
+        tags = predict_mesh_tags(X, model_path, label_binarizer_path)
+        assert len(tags) == 5
+
+
+def test_predict_mesh_cnn():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        model_path = f"{tmp_dir}/cnn_model/"
+        os.mkdir(model_path)
+        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
+        train_test_cnn_model(model_path, label_binarizer_path)
 
         tags = predict_mesh_tags(X, model_path, label_binarizer_path)
         assert len(tags) == 5

--- a/tests/test_tag_grants.py
+++ b/tests/test_tag_grants.py
@@ -75,4 +75,10 @@ def test_tag_grants():
 
             tmp_grants.seek(0)
 
-            tag_grants(grants_path, tagged_grants_path, scibert_path=scibert_path, tfidf_svm_path=tfidf_svm_path, label_binarizer_path=label_binarizer_path)
+            tag_grants(
+                grants_path,
+                tagged_grants_path,
+                scibert_path=scibert_path,
+                tfidf_svm_path=tfidf_svm_path,
+                label_binarizer_path=label_binarizer_path
+            )

--- a/tests/test_tag_grants.py
+++ b/tests/test_tag_grants.py
@@ -50,9 +50,9 @@ def train_test_model(scibert_path, tfidf_svm_path, label_binarizer_path):
     scibert.fit(X, Y_vec)
     scibert.save(scibert_path)
 
-def test_tag_grants_with_mesh():
+def test_tag_grants():
     with tempfile.TemporaryDirectory() as tmp_dir:
-        scibert_path = f"{tmp_dir}/model/"
+        scibert_path = f"{tmp_dir}/scibert/"
         os.mkdir(scibert_path)
         tfidf_svm_path = f"{tmp_dir}/tfidf_svm.pkl"
         label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"

--- a/tests/test_tag_grants_with_mesh.py
+++ b/tests/test_tag_grants_with_mesh.py
@@ -50,7 +50,7 @@ def train_test_model(model_path, label_binarizer_path):
 
 def test_tag_grants_with_mesh():
     with tempfile.TemporaryDirectory() as tmp_dir:
-        model_path = f"{tmp_dir}/model/"
+        model_path = f"{tmp_dir}/tfidf_model/"
         os.mkdir(model_path)
         label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
         train_test_model(model_path, label_binarizer_path)
@@ -72,4 +72,10 @@ def test_tag_grants_with_mesh():
 
             tmp_grants.seek(0)
 
-            tag_grants_with_mesh(grants_path, tagged_grants_path, model_path=model_path, label_binarizer_path=label_binarizer_path)
+            tag_grants_with_mesh(
+                grants_path,
+                tagged_grants_path,
+                model_path=model_path,
+                label_binarizer_path=label_binarizer_path,
+                threshold=0.5
+            )


### PR DESCRIPTION
This PR introduces some changes to evaluate, predict and tag grants in light of the new neural model for disease mesh. There are two main changes here and a couple of smaller ones. The two main changes are

- evaluate ensemble becomes evaluate model and can now evaluate any deployed model
- evaluate model can accept multiple thresholds and in that case it calculates precision and recall for each threshold, a process we follow to set up a static threshold for all tags

There are a couple of things that are not optimal which I plan to fix in the future. Those are

- the model path directs which model is loaded and which predict function is called. it would be ideal if the models behaved in a more similar way after loading and that the path contained some meta information about how to load them. this way the code would be more uniformal and the complexity could be hidden behind a load function that takes instruction from a meta file
- the two tagging projects have separate functions but very similar code. in fact the code has converged nicely to a point where it is now easy to combine the functionality so that irrespective of whether it is the disease mesh tags or science tags the codebase is mostly the same especially in regards to predict and tag which should not differ