### PR TITLE
Incremental training

### DIFF
--- a/grants_tagger/__main__.py
+++ b/grants_tagger/__main__.py
@@ -28,7 +28,7 @@ def train(
         approach: str = typer.Option("tfidf-svm", help="tfidf-svm, scibert, cnn, ..."),
         parameters: str = typer.Option("{}", help="model params in sklearn format e.g. {'svm__kernel: linear'}"),
         test_data_path: Path = typer.Option(None, help="path to processed JSON test data"),
-        online_learning: bool = typer.Option(False, help="flag to train in an online way"),
+        incremental_learning: bool = typer.Option(False, help="flag to train in an online way"),
         nb_epochs: int = typer.Option(5, help="number of passes of training data in online training"),
         from_same_distribution: bool = typer.Option(False, help="whether train and test contain the same examples but differ in other ways, important when loading train and test parts of datasets"),
         threshold: float = typer.Option(None, help="threshold to assign a tag"),
@@ -48,7 +48,7 @@ def train(
         parameters = cfg["model"]["parameters"]
         model_path = cfg["model"]["model_path"]
         test_data_path = cfg["data"]["test_data_path"]
-        online_learning = bool(cfg["model"].get("online_learning", False))
+        incremental_learning = bool(cfg["model"].get("incremental_learning", False))
         nb_epochs = int(cfg["model"].get("nb_epochs", 5))
         from_same_distribution = bool(cfg["data"].get("from_same_distribution", False))
         threshold = cfg["model"].get("threshold", None)
@@ -75,7 +75,7 @@ def train(
             data_path, label_binarizer_path, approach,
             parameters, model_path=model_path,
             test_data_path=test_data_path,
-            online_learning=online_learning,
+            incremental_learning=incremental_learning,
             nb_epochs=nb_epochs,
             from_same_distribution=from_same_distribution,
             threshold=threshold, y_batch_size=y_batch_size,

--- a/grants_tagger/__main__.py
+++ b/grants_tagger/__main__.py
@@ -35,6 +35,8 @@ def train(
         y_batch_size: int = typer.Option(None, help="batch size for Y in cases where Y large. defaults to None i.e. no batching of Y"),
         x_format: str = typer.Option("List", help="format that will be used when loading the data. One of List,DataFrame"),
         test_size: float = typer.Option(0.25, help="float or int indicating either percentage or absolute number of test examples"),
+        sparse_labels: bool = typer.Option(False, help="flat about whether labels should be sparse when binarized"),
+        cache_path: Optional[Path] = typer.Option(None, help="path to cache data transformartions"),
         config: Path = None):
     if config:
         cfg = configparser.ConfigParser(allow_no_value=True)
@@ -57,7 +59,11 @@ def train(
             y_batch_size = int(y_batch_size)
         x_format = cfg["data"].get("x_format", "List")
         test_size = float(cfg["data"].get("test_size", 0.25))
-
+        sparse_labels = cfg["model"].get("sparse_labels", False)
+        if sparse_labels:
+            sparse_labels = bool(sparse_labels)
+        cache_path = cfg["data"].get("cache_path")
+        
     # CHECK that data_path, label_binarizer_path is provided
     # Do we need to provide model_path?
 
@@ -73,7 +79,8 @@ def train(
             nb_epochs=nb_epochs,
             from_same_distribution=from_same_distribution,
             threshold=threshold, y_batch_size=y_batch_size,
-            X_format=x_format, test_size=test_size)
+            X_format=x_format, test_size=test_size,
+            sparse_labels=sparse_labels, cache_path=cache_path)
 
 
 preprocess_app = typer.Typer()

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -251,7 +251,7 @@ def train_and_evaluate(
             classifier.fit(train_data)
         else:
             # OneVsRestClassifier does not work with partial fit
-            # TODO: fit one SGDClassifier per label
+            # TODO: fit one SGDClassifier per label, use multiprocessing
             raise NotImplementedError
     else:
         X_train, X_test, Y_train, Y_test = load_train_test_data(

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -18,7 +18,7 @@ from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
 from sklearn.linear_model import SGDClassifier
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.preprocessing import Normalizer, OneHotEncoder, FunctionTransformer
-from scipy.sparse import hstack, vstack, csr_matrix
+from scipy import sparse as sp
 
 from pathlib import Path
 import pickle
@@ -293,9 +293,9 @@ def train_and_evaluate(
                 if sparse_labels:
                     Y_test = []
                     for _, Y_batch in test_data:
-                        Y_batch = csr_matrix(Y_batch.numpy())
+                        Y_batch = sp.csr_matrix(Y_batch.numpy())
                         Y_test.append(Y_batch)
-                    Y_test = vstack(Y_test)
+                    Y_test = sp.vstack(Y_test)
                 else:
                     Y_test = []
                     for _, Y_batch in test_data:
@@ -313,7 +313,7 @@ def train_and_evaluate(
                 Y_pred_test_i = classifier.predict(X_test_vec)
                 Y_pred_test.append(Y_pred_test_i)
                 print(Y_pred_test_i.shape)
-            Y_pred_test = hstack(Y_pred_test)
+            Y_pred_test = sp.hstack(Y_pred_test)
         else:
             Y_pred_test = model.predict(X_test)
             # Y_pred_train = model.predict(X_train)

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -241,6 +241,7 @@ def train_and_evaluate(
             vectorizer = model.steps[0][1]
             classifier = model.steps[1][1]
 
+            # Note that we fit the vectorizer using all data. See Issue#59.
             print("Fitting vectorizer")
             vectorizer.fit(yield_texts(train_data_path))
             print("Fitting classifier")

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -218,7 +218,7 @@ def create_model(approach, parameters=None):
 def train_and_evaluate(
         train_data_path, label_binarizer_path, approach,
         parameters=None, model_path=None, test_data_path=None,
-        online_learning=False, nb_epochs=5,
+        incremental_learning=False, nb_epochs=5,
         from_same_distribution=False, threshold=None,
         y_batch_size=None, X_format="List",
         test_size=0.25, sparse_labels=False,
@@ -235,7 +235,7 @@ def train_and_evaluate(
     # so that run experiments can pass a model here
     model = create_model(approach, parameters)
 
-    if online_learning:
+    if incremental_learning:
         if approach in ["cnn", "bilstm"]:
             vectorizer = model.steps[0][1]
             classifier = model.steps[1][1]
@@ -288,7 +288,7 @@ def train_and_evaluate(
             Y_pred_prob = model.predict_proba(X_test)
         Y_pred_test = Y_pred_prob > threshold
     else:
-        if online_learning:
+        if incremental_learning:
             if approach in ["cnn", "bilstm"]:
                 if sparse_labels:
                     Y_test = []
@@ -297,8 +297,10 @@ def train_and_evaluate(
                         Y_test.append(Y_batch)
                     Y_test = vstack(Y_test)
                 else:
-                    pass # ??
-    
+                    Y_test = []
+                    for _, Y_batch in test_data:
+                        Y_test.append(Y_batch)
+                    Y_test = np.vstack(Y_test)
                 Y_pred_test = classifier.predict(test_data)
             else:
                 raise NotImplementedError

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -27,7 +27,7 @@ import json
 import ast
 
 from wellcomeml.ml import BiLSTMClassifier, CNNClassifier, KerasVectorizer, SpacyClassifier, BertVectorizer, BertClassifier, Doc2VecVectorizer, Sent2VecVectorizer
-from grants_tagger.utils import load_train_test_data, yield_train_data, load_test_data, yield_texts, yield_tags, load_train_test_dataset, load_tags
+from grants_tagger.utils import load_train_test_data, yield_texts, yield_tags, load_train_test_dataset
 
 
 class ApproachNotImplemented(Exception):

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -19,6 +19,7 @@ from sklearn.linear_model import SGDClassifier
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.preprocessing import Normalizer, OneHotEncoder, FunctionTransformer
 from scipy import sparse as sp
+import numpy as np
 
 from pathlib import Path
 import pickle

--- a/grants_tagger/utils.py
+++ b/grants_tagger/utils.py
@@ -4,6 +4,7 @@ import json
 
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import f1_score
+import tensorflow as tf
 import pandas as pd
 import numpy as np
 
@@ -32,6 +33,18 @@ def load_data(data_path, label_binarizer=None, X_format="List"):
 
     return texts, tags, meta
         
+
+def load_tags(data_path, label_binarizer=None):
+    tags = []
+    with open(data_path) as f:
+        for line in f:
+            item = json.loads(line)
+            tags.append(item["tags"])
+
+    if label_binarizer:
+        tags = label_binarizer.transform(tags)
+    return tags
+
 
 def load_train_test_data(
         train_data_path, label_binarizer,
@@ -95,3 +108,85 @@ def calc_performance_per_tag(Y_true, Y_pred, tags):
             'f1': f1_score(y_true_tag, y_pred_tag)
         })
     return pd.DataFrame(metrics)
+
+def yield_texts(data_path):
+    with open(data_path) as f:
+        for line in f:
+            item = json.loads(line)
+            yield item["text"]
+
+def yield_tags(data_path):
+    with open(data_path) as f:
+        for line in f:
+            item = json.loads(line)
+            yield item["tags"]
+
+def load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=False, data_cache=None, random_seed=42, shuffle=True, shuffle_buffer=1000):
+    def data_gen():
+        with open(data_path) as f:
+            texts = []
+            tags = []
+            for line in f:
+                item = json.loads(line)
+                texts.append(item["text"])
+                tags.append(item["tags"])
+
+                if len(texts) >= 1000: 
+                    text_encoded = tokenizer.transform(texts)
+                    tags_encoded = label_binarizer.transform(tags)
+
+                    if sparse_labels:
+                        tags_encoded = tags_encoded.todense() # returns matrix
+                        tags_encoded = np.asarray(tags_encoded)
+                    
+                    for i in range(len(texts)):
+                        yield text_encoded[i], tags_encoded[i]
+
+                    texts = []
+                    tags = []
+            
+            # TODO: Refactor
+            if texts:
+                text_encoded = tokenizer.transform(texts)
+                tags_encoded = label_binarizer.transform(tags)
+
+                if sparse_labels:
+                    tags_encoded = tags_encoded.todense() # returns matrix
+                    tags_encoded = np.squeeze(np.asarray(tags_encoded))
+                    
+                for i in range(len(texts)):
+                    yield text_encoded[i], tags_encoded[i]
+
+    data = tf.data.Dataset.from_generator(data_gen, output_types=(tf.int32, tf.int32))
+
+    if shuffle:
+        data = data.shuffle(shuffle_buffer, seed=random_seed, reshuffle_each_iteration=False)
+    if data_cache:
+        data = data.cache(data_cache)
+    return data
+
+def load_train_test_dataset(data_path, tokenizer, label_binarizer, test_data_path=None, test_size=0.1, sparse_labels=False, data_cache=None, random_seed=42, shuffle=True, shuffle_buffer=1000):
+    data = load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=sparse_labels,
+                        shuffle_buffer=shuffle_buffer, data_cache=data_cache, random_seed=random_seed)
+
+    if test_data_path:
+        test_data = load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=sparse_labels,
+                                 shuffle_buffer=shuffle_buffer, random_seed=random_seed) # cache will load train data if it has the same name
+        train_data = data
+    else:
+        print("Splitting train and test. This might take a while.")
+        steps = 0
+        for _ in data:
+            steps += 1
+
+        train_steps = int((1-test_size) * steps)
+    
+        train_data = data.take(train_steps)
+        test_data = data.skip(train_steps)
+        print(f"Splitted. Train data size {train_steps}. Test data size {steps-train_steps}")
+
+    if shuffle:
+        train_data = train_data.shuffle(shuffle_buffer, seed=random_seed)
+        test_data = test_data.shuffle(shuffle_buffer, seed=random_seed)
+
+    return train_data, test_data

--- a/grants_tagger/utils.py
+++ b/grants_tagger/utils.py
@@ -57,7 +57,6 @@ def load_train_test_data(
            
     return X_train, X_test, Y_train, Y_test
 
-
 # TODO: Move to common for cases where Y is a matrix
 def calc_performance_per_tag(Y_true, Y_pred, tags):
     metrics = []

--- a/grants_tagger/utils.py
+++ b/grants_tagger/utils.py
@@ -116,7 +116,7 @@ def load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=False, dat
     data = tf.data.Dataset.from_generator(data_gen, output_types=(tf.int32, tf.int32))
 
     if shuffle:
-        data = data.shuffle(shuffle_buffer, seed=random_seed, reshuffle_each_iteration=False)
+        data = data.shuffle(shuffle_buffer, seed=random_seed)
     if data_cache:
         data = data.cache(data_cache)
     return data
@@ -127,7 +127,7 @@ def load_train_test_dataset(data_path, tokenizer, label_binarizer, test_data_pat
 
     if test_data_path:
         test_data = load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=sparse_labels,
-                                 shuffle_buffer=shuffle_buffer, random_seed=random_seed) # cache will load train data if it has the same name
+                                 shuffle_buffer=shuffle_buffer, shuffle=False, random_seed=random_seed) # cache will load train data if it has the same name
         train_data = data
     else:
         print("Splitting train and test. This might take a while.")
@@ -140,9 +140,5 @@ def load_train_test_dataset(data_path, tokenizer, label_binarizer, test_data_pat
         train_data = data.take(train_steps)
         test_data = data.skip(train_steps)
         print(f"Splitted. Train data size {train_steps}. Test data size {steps-train_steps}")
-
-    if shuffle:
-        train_data = train_data.shuffle(shuffle_buffer, seed=random_seed)
-        test_data = test_data.shuffle(shuffle_buffer, seed=random_seed)
 
     return train_data, test_data

--- a/grants_tagger/utils.py
+++ b/grants_tagger/utils.py
@@ -32,19 +32,6 @@ def load_data(data_path, label_binarizer=None, X_format="List"):
         return X, tags, meta
 
     return texts, tags, meta
-        
-
-def load_tags(data_path, label_binarizer=None):
-    tags = []
-    with open(data_path) as f:
-        for line in f:
-            item = json.loads(line)
-            tags.append(item["tags"])
-
-    if label_binarizer:
-        tags = label_binarizer.transform(tags)
-    return tags
-
 
 def load_train_test_data(
         train_data_path, label_binarizer,
@@ -69,25 +56,6 @@ def load_train_test_data(
         )
            
     return X_train, X_test, Y_train, Y_test
-
-def yield_train_data(data_path, label_binarizer, batch_size=100):
-    with open(data_path) as f:
-        i = 0
-        X = []
-        Y = []
-        for line in f:
-            i += 1
-            item = json.loads(line)
-            X.append(item['text'])
-            tags = item['tags']
-            Y.append(label_binarizer.transform([tags])[0])
-            if i % batch_size == 0:
-                Y = np.array(Y)
-                yield X, Y
-                X = []
-                Y = []
-        if X:
-            yield X, Y
 
 def load_test_data(data_path, label_binarizer):
     X = []

--- a/grants_tagger/utils.py
+++ b/grants_tagger/utils.py
@@ -123,7 +123,8 @@ def load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=False, dat
 
 def load_train_test_dataset(data_path, tokenizer, label_binarizer, test_data_path=None, test_size=0.1, sparse_labels=False, data_cache=None, random_seed=42, shuffle=True, shuffle_buffer=1000):
     data = load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=sparse_labels,
-                        shuffle_buffer=shuffle_buffer, data_cache=data_cache, random_seed=random_seed)
+                        shuffle_buffer=shuffle_buffer, shuffle=shuffle, data_cache=data_cache, 
+                        random_seed=random_seed)
 
     if test_data_path:
         test_data = load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=sparse_labels,

--- a/grants_tagger/utils.py
+++ b/grants_tagger/utils.py
@@ -101,7 +101,7 @@ def load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=False, dat
             tags.append(tags_)
 
             if len(texts) >= load_buffer: 
-                text_encoded, tags_encoded = transform_data(text, tags)
+                text_encoded, tags_encoded = transform_data(texts, tags)
                 for i in range(len(texts)):
                     yield text_encoded[i], tags_encoded[i]
 
@@ -109,7 +109,7 @@ def load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=False, dat
                 tags = []
 
         if texts:
-            text_encoded, tags_encoded = transform_data(text, tags)   
+            text_encoded, tags_encoded = transform_data(texts, tags)   
             for i in range(len(texts)):
                 yield text_encoded[i], tags_encoded[i]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scikit-multilearn
 arff
 python-dateutil<2.8.1,>=2.1
--e git+git://github.com/wellcometrust/WellcomeML.git@ca5d1c38f28a50aacdefa5b5b47647389194e826#egg=wellcomeml[deep-learning]
+-e git+git://github.com/wellcometrust/WellcomeML.git@5ae533c598e25ba1bb95b7eebfd3dcf7db6a2b3d#egg=wellcomeml[deep-learning]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scikit-multilearn
 arff
 python-dateutil<2.8.1,>=2.1
--e git+git://github.com/wellcometrust/WellcomeML.git@f6d5eda566c98f90725c7e159163698c20d90a4b#egg=wellcomeml[deep-learning]
+-e git+git://github.com/wellcometrust/WellcomeML.git@14668e8650516363453a85bc2a5546cfe8811951#egg=wellcomeml[deep-learning]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scikit-multilearn
 arff
 python-dateutil<2.8.1,>=2.1
--e git+git://github.com/wellcometrust/WellcomeML.git@5ae533c598e25ba1bb95b7eebfd3dcf7db6a2b3d#egg=wellcomeml[deep-learning]
+-e git+git://github.com/wellcometrust/WellcomeML.git@f6d5eda566c98f90725c7e159163698c20d90a4b#egg=wellcomeml[deep-learning]

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -378,8 +378,7 @@ def test_train_and_evaluate_incremental_learning():
 
     texts = ["one", "one two", "two"]
     tags = [["one"], ["one", "two"], ["two"]]
-    print(texts)
-    print(tags)
+
     with tempfile.TemporaryDirectory() as tmp_dir:
         train_data_path = os.path.join(tmp_dir, "data.jsonl")
         label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
@@ -391,3 +390,22 @@ def test_train_and_evaluate_incremental_learning():
 
         train_and_evaluate(train_data_path, label_binarizer_path, approach,
                            incremental_learning=True, sparse_labels=True)
+
+
+def test_train_and_evaluate_incremental_learning_non_sparse_labels():
+    approach = "cnn"
+
+    texts = ["one", "one two", "two"]
+    tags = [["one"], ["one", "two"], ["two"]]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        train_data_path = os.path.join(tmp_dir, "data.jsonl")
+        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
+
+        with open(train_data_path, "w") as f:
+            for text, tags_ in zip(texts, tags):
+                f.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
+                f.write("\n")
+
+        train_and_evaluate(train_data_path, label_binarizer_path, approach,
+                           incremental_learning=True)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -371,3 +371,23 @@ def test_create_label_binarizer_sparse():
         assert "two" in label_binarizer.classes_
         assert len(label_binarizer.classes_) == 2
         assert isinstance(Y, csr_matrix)
+
+
+def test_train_and_evaluate_incremental_learning():
+    approach = "cnn"
+
+    texts = ["one", "one two", "two"]
+    tags = [["one"], ["one", "two"], ["two"]]
+    print(texts)
+    print(tags)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        train_data_path = os.path.join(tmp_dir, "data.jsonl")
+        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
+
+        with open(train_data_path, "w") as f:
+            for text, tags_ in zip(texts, tags):
+                f.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
+                f.write("\n")
+
+        train_and_evaluate(train_data_path, label_binarizer_path, approach,
+                           incremental_learning=True, sparse_labels=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from grants_tagger.utils import (load_data, calc_performance_per_tag,
-    load_test_data, yield_train_data, load_train_test_data)
+    load_train_test_data)
 
 
 def test_load_data():    
@@ -101,55 +101,3 @@ def test_load_train_test_data():
     assert np.array_equal(tags_train[0], [1, 0])
     assert np.array_equal(tags_train[1], [0, 1])
     assert np.array_equal(tags_test[0], [1, 1])
-
-def test_yield_train_data():
-    data = [
-        {
-            'text': 'A',
-            'tags': ['T1', 'T2'],
-            'meta': {'Grant_ID': 1, 'Title': 'A'}
-        },
-        {
-            'text': 'B',
-            'tags': ['T1'],
-            'meta': {'Grant_ID': 2, 'Title': 'B'}
-        }
-    ]
-    with tempfile.NamedTemporaryFile('w') as tmp:
-        for line in data:
-            tmp.write(json.dumps(line))
-            tmp.write('\n')
-        tmp.seek(0)
-        label_binarizer = MultiLabelBinarizer()
-        label_binarizer.fit([['T1','T2']])
-        texts = []
-        tags = []
-        for text, tag in yield_train_data(tmp.name, label_binarizer):
-            texts.extend(text)
-            tags.extend(tag)
-    assert np.array_equal(tags[0], [1, 1])
-    assert np.array_equal(tags[1], [1, 0])
-
-def test_load_test_data():
-    data = [
-        {
-            'text': 'A',
-            'tags': ['T1','T2'],
-            'meta': {'Grant_ID': 1, 'Title': 'A'}
-        },
-        {
-            'text': 'B',
-            'tags': ['T1'],
-            'meta': {'Grant_ID': 2, 'Title': 'B'}
-        }
-    ]
-    with tempfile.NamedTemporaryFile('w') as tmp:
-        for line in data:
-            tmp.write(json.dumps(line))
-            tmp.write('\n')
-        tmp.seek(0)
-        label_binarizer = MultiLabelBinarizer()
-        label_binarizer.fit([['T1','T2']])
-        texts, tags = load_test_data(tmp.name, label_binarizer)
-    assert np.array_equal(tags[0], [1, 1])
-    assert np.array_equal(tags[1], [1, 0])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,8 +7,9 @@ from sklearn.metrics import f1_score
 import numpy as np
 import pandas as pd
 
+from wellcomeml.ml import KerasVectorizer
 from grants_tagger.utils import (load_data, calc_performance_per_tag,
-    load_train_test_data)
+    load_train_test_data, load_train_test_dataset)
 
 
 def test_load_data():    
@@ -101,3 +102,44 @@ def test_load_train_test_data():
     assert np.array_equal(tags_train[0], [1, 0])
     assert np.array_equal(tags_train[1], [0, 1])
     assert np.array_equal(tags_test[0], [1, 1])
+
+
+def test_load_train_test_dataset():
+    data = [
+        {
+            'text': 'A',
+            'tags': ['T1', 'T2'],
+            'meta': {'Grant_ID': 1, 'Title': 'A'}
+        },
+        {
+            'text': 'B',
+            'tags': ['T1'],
+            'meta': {'Grant_ID': 2, 'Title': 'B'}
+        },
+        {
+            'text': 'C',
+            'tags': ['T2'],
+            'meta': {'Grant_ID': 3, 'Title': 'C'}
+        }
+    ]
+    with tempfile.NamedTemporaryFile('w') as tmp:
+        for line in data:
+            tmp.write(json.dumps(line))
+            tmp.write('\n')
+        tmp.seek(0)
+        tokenizer = KerasVectorizer()
+        tokenizer.fit([d['text'] for d in data])
+        label_binarizer = MultiLabelBinarizer(classes=["T1", "T2"])
+        label_binarizer.fit([d['tags'] for d in data])
+        train_data, test_data = load_train_test_dataset(tmp.name, tokenizer, label_binarizer, shuffle=False)
+    
+        def get_tags(data):
+            tags = []
+            for example in data.as_numpy_iterator():
+                tags.append(example[1])
+            return tags
+        tags_train = get_tags(train_data)
+        tags_test = get_tags(test_data)
+        assert np.array_equal(tags_train[0], [1, 1])
+        assert np.array_equal(tags_train[1], [1, 0])
+        assert np.array_equal(tags_test[0], [0, 1])


### PR DESCRIPTION
This PR reintroduces the idea of incremental learning which we first wanted to use to train our Tfidf-SVM baseline.

This time we use our CNN model which leverages `tf.data.Dataset` to implement incremental learning. Note that tensorflow also allows for a generator to be passed in but in that case functionally such as batching, shuffling etc would need to be implemented whereas now it comes for free.

Note that `KerasVectorizer` and `MultiLabelBinarizer` allow for a generator to be passed in so training them efficiently is relatively easy. One thing we need to work around, as is often in this project, is sparse labels. In particular the dataset converts to dense as it returns data but this means that test_data need to be converted back to sparse to fit into memory.