### PR TITLE
Update WellcomeML to 2021.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 
 script:
   - make test
-  # - make test_scispacy
+  - make test_scispacy
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 
 script:
   - make test
-  - make test_scispacy
+  # - make test_scispacy
 
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ virtualenv_scispacy: virtualenv
 
 .PHONY: test
 test: virtualenv
-	$(VIRTUALENV)/bin/python -m spacy download en_trf_bertbaseuncased_lg
 	$(VIRTUALENV)/bin/pytest --disable-warnings -v --cov=grants_tagger -m "not scispacy"
 
 .PHONY: test_scispacy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scikit-multilearn
 arff
 python-dateutil<2.8.1,>=2.1
--e git+git://github.com/wellcometrust/WellcomeML.git@c844f89f57544096a89defeeacd074d3041a9c7a#egg=wellcomeml[deep-learning]
+-e git+git://github.com/wellcometrust/WellcomeML.git@ca5d1c38f28a50aacdefa5b5b47647389194e826#egg=wellcomeml[deep-learning]

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'scikit-learn==0.23.2',
         'nltk',
         'matplotlib',
-        'wellcomeml[deep-learning]==2020.11.1',
+        'wellcomeml[deep-learning]==2021.2.1',
         'docutils==0.15',
         'scipy==1.4.1',
         'wasabi',

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -76,7 +76,7 @@ def test_create_scibert_svm():
 def test_create_bert():
     model = create_model('bert')
     assert isinstance(model, BertClassifier)
-    assert model.pretrained == 'bert'
+    assert model.pretrained == 'bert-base-uncased'
 
 
 def test_create_scibert():


### PR DESCRIPTION
Updating to WellcomeML contains transition to spacy v3 and
the rewrite of BertClassifier among other things.

~Spacy v3 meant that we needed to update scispacy but as it turns out
this was with its own issues https://github.com/allenai/scispacy/issues/324
so I am postponing that until the issue is resolved and disabling the tests~

BertClassifier switched from referring to pretrained models with short names
to referencing the hugging face names so I am updating the tests here.
