### PR TITLE
Add classes for production models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ install:
 
 script:
   - make test
-  - make test_scispacy
 
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -26,24 +26,16 @@ $(VIRTUALENV)/.installed:
 	$(VIRTUALENV)/bin/pip install -r requirements.txt
 	$(VIRTUALENV)/bin/pip install -r requirements_test.txt
 	$(VIRTUALENV)/bin/pip install -e .
+	$(VIRTUALENV)/bin/pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.4.0/en_core_sci_sm-0.4.0.tar.gz
 	touch $@
 
 .PHONY: virtualenv
 virtualenv: $(VIRTUALENV)/.installed
 
-.PHONY: virtualenv_scispacy
-virtualenv_scispacy: virtualenv
-	$(VIRTUALENV)/bin/pip install -r requirements_scispacy.txt
-	rm $(VIRTUALENV)/.installed
-	echo "⚠️  Virtualenv is broken and needs to be reinstalled"
 
 .PHONY: test
 test: virtualenv
-	$(VIRTUALENV)/bin/pytest --disable-warnings -v --cov=grants_tagger -m "not scispacy"
-
-.PHONY: test_scispacy
-test_scispacy: virtualenv_scispacy
-	$(VIRTUALENV)/bin/pytest --disable-warnings -v --cov-append --cov=grants_tagger tests/test_scispacy_meshtagger.py tests/test_evaluate_scispacy.py
+	$(VIRTUALENV)/bin/pytest --disable-warnings -v --cov=grants_tagger
 
 
 .PHONY: run_codecov

--- a/grants_tagger/__main__.py
+++ b/grants_tagger/__main__.py
@@ -54,12 +54,6 @@ def train(
             sparse_labels = bool(sparse_labels)
         cache_path = cfg["data"].get("cache_path")
     
-    # TODO: check x_format in configs and code
-    # TODO: check y_batch_size in config and pass as param to model
-
-    # CHECK that data_path, label_binarizer_path is provided
-    # Do we need to provide model_path?
-
     if os.path.exists(model_path):
         print(f"{model_path} exists. Remove if you want to rerun.")
     else:

--- a/grants_tagger/evaluate_mesh_on_grants.py
+++ b/grants_tagger/evaluate_mesh_on_grants.py
@@ -32,7 +32,7 @@ def get_texts(data):
     return texts
 
 
-def evaluate_mesh_on_grants(data_path, model_path, label_binarizer_path):
+def evaluate_mesh_on_grants(approach, data_path, model_path, label_binarizer_path):
     data = pd.read_excel(data_path, engine="openpyxl")
 
     with open(label_binarizer_path, "rb") as f:
@@ -42,7 +42,7 @@ def evaluate_mesh_on_grants(data_path, model_path, label_binarizer_path):
     Y = label_binarizer.transform(gold_tags)
 
     texts = get_texts(data)
-    Y_pred = predict(texts, model_path, label_binarizer_path)
+    Y_pred = predict(texts, model_path, approach)
     f1 = f1_score(Y, Y_pred, average='micro')
     print(f"F1 micro is {f1}")
 

--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -7,22 +7,26 @@ from sklearn.model_selection import train_test_split
 from sklearn.metrics import f1_score, classification_report, precision_score, recall_score
 from wasabi import table
 
-from grants_tagger.utils import load_data
+from grants_tagger.utils import load_train_test_data
 from grants_tagger.predict import predict
 
 
-def evaluate_model(model_path, data_path, label_binarizer_path, threshold):
+def evaluate_model(approach, model_path, data_path, label_binarizer_path, threshold):
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
+
+    # TODO: Remove if not needed
     nb_labels = len(label_binarizer.classes_)
 
-    X, Y, _ = load_data(data_path, label_binarizer)
-    X_train, X_test, Y_train, Y_test = train_test_split(X, Y, random_state=42)
+    # TODO: A user might be expecting to evaluate on all data passing
+    # - add warning about this behaviour
+    # - add flag to use all data instead of split
+    X_train, X_test, Y_train, Y_test = load_train_test_data(data_path, label_binarizer)   
 
     if type(threshold) == list:
         results = []
         for threshold_ in threshold:
-            Y_pred = predict(X_test, model_path, nb_labels, threshold_)
+            Y_pred = predict(X_test, model_path, approach, threshold_)
             p = precision_score(Y_test, Y_pred, average='micro')
             r = recall_score(Y_test, Y_pred, average='micro')
             f1 = f1_score(Y_test, Y_pred, average='micro')
@@ -30,5 +34,5 @@ def evaluate_model(model_path, data_path, label_binarizer_path, threshold):
         header = ["Threshold", "P", "R", "F1"]
         print(table(results, header, divider=True))
     else:
-        Y_pred = predict(X_test, model_path, nb_labels, threshold)
+        Y_pred = predict(X_test, model_path, approach, threshold)
         print(classification_report(Y_test, Y_pred))

--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -15,9 +15,6 @@ def evaluate_model(approach, model_path, data_path, label_binarizer_path, thresh
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
 
-    # TODO: Remove if not needed
-    nb_labels = len(label_binarizer.classes_)
-
     # TODO: A user might be expecting to evaluate on all data passing
     # - add warning about this behaviour
     # - add flag to use all data instead of split

--- a/grants_tagger/evaluate_model.py
+++ b/grants_tagger/evaluate_model.py
@@ -7,18 +7,20 @@ from sklearn.model_selection import train_test_split
 from sklearn.metrics import f1_score, classification_report, precision_score, recall_score
 from wasabi import table
 
-from grants_tagger.utils import load_train_test_data
+from grants_tagger.utils import load_train_test_data, load_data
 from grants_tagger.predict import predict
 
 
-def evaluate_model(approach, model_path, data_path, label_binarizer_path, threshold):
+def evaluate_model(approach, model_path, data_path, label_binarizer_path,
+        threshold, split_data=True):
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
 
-    # TODO: A user might be expecting to evaluate on all data passing
-    # - add warning about this behaviour
-    # - add flag to use all data instead of split
-    X_train, X_test, Y_train, Y_test = load_train_test_data(data_path, label_binarizer)   
+    if split_data:
+        print("Warning: Data will be split in the same way as train. If you don't want that you set split_data=False")
+        _, X_test, _, Y_test = load_train_test_data(data_path, label_binarizer)   
+    else:
+        X_test, Y_test, _ = load_data(data_path, label_binarizer)
 
     if type(threshold) == list:
         results = []

--- a/grants_tagger/models.py
+++ b/grants_tagger/models.py
@@ -308,6 +308,9 @@ class MeshTfidfSVM():
         if not hasattr(self, 'classifier'):
             self._init_classifier()
 
+        # TODO: Currently Y is expected to be sparse, otherwise predict does not
+        # work, add a check and warn user.
+
         print(f"Creating {self.model_path}")
         Path(self.model_path).mkdir(exist_ok=True)
         print("Fitting vectorizer")

--- a/grants_tagger/models.py
+++ b/grants_tagger/models.py
@@ -124,7 +124,7 @@ class MeshCNN():
 
         X: list of texts
         vectorizer: vectorizer class that implements transform which transforms texts to integers
-        Y: 2d numpy array that represents targets (tags) assigned.
+        Y: 2d numpy array or sparse csr_matrix that represents targets (tags) assigned.
 
         If Y is missing, for example when called by predict, yield_data yields only X vectorized
         """
@@ -209,8 +209,8 @@ class MeshCNN():
 
     def fit(self, X, Y):
         """
-        X: list, np.array or generator of texts
-        Y: 2d np.array of tags assigned 
+        X: list or generator of texts
+        Y: 2d numpy array or sparse csr_matrix or generator of 2d numpy array of tags assigned 
 
         If X is a generator it need to be callable i.e. return 
         the generator by calling it X_gen = X(). This is so
@@ -347,8 +347,8 @@ class MeshTfidfSVM():
 
     def fit(self, X, Y):
         """
-        X: np.array or list of texts
-        Y: 2d np.array of tags assigned
+        X: list of texts
+        Y: sparse csr_matrix of tags assigned
         """
         if not hasattr(self, 'vectorizer'):
             self._init_vectorizer()

--- a/grants_tagger/models.py
+++ b/grants_tagger/models.py
@@ -356,7 +356,9 @@ class MeshTfidfSVM():
         return self._predict(X, return_probabilities=True)
 
     def save(self, model_path):
-        # model saved during fit
+        if model_path != self.model_path:
+            print(f"{model_path} is different from self.model_path {self.model_path}. This will result in model and meta.json be saved in different paths")
+
         meta = {
             "name": "MeshTfidfSVM",
             "approach": "mesh-tfidf-svm",

--- a/grants_tagger/models.py
+++ b/grants_tagger/models.py
@@ -1,0 +1,539 @@
+from pathlib import Path
+import pickle
+import json
+import ast
+import os
+
+from skmultilearn.problem_transform import ClassifierChain, LabelPowerset, BinaryRelevance
+from skmultilearn.adapt import BRkNNaClassifier, MLkNN
+from sklearn.preprocessing import MultiLabelBinarizer
+from sklearn.ensemble import AdaBoostClassifier
+from sklearn.multiclass import OneVsRestClassifier
+from sklearn.feature_selection import SelectFromModel
+from sklearn.pipeline import Pipeline, FeatureUnion
+from sklearn.metrics import f1_score, precision_score, recall_score, classification_report
+from sklearn.feature_extraction.text import TfidfVectorizer, HashingVectorizer
+from sklearn.svm import SVC
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
+from sklearn.linear_model import SGDClassifier
+from sklearn.naive_bayes import MultinomialNB
+from sklearn.preprocessing import Normalizer, OneHotEncoder, FunctionTransformer
+from scipy import sparse as sp
+import tensorflow as tf
+import numpy as np
+
+from wellcomeml.ml import BiLSTMClassifier, CNNClassifier, KerasVectorizer, SpacyClassifier, BertVectorizer, BertClassifier, Doc2VecVectorizer, Sent2VecVectorizer, WellcomeVotingClassifier
+
+
+class ApproachNotImplemented(Exception):
+    pass
+
+
+def get_params_for_component(params, component):
+    component_params = {}
+    for k, v in params.items():
+        if k.startswith(component):
+            _, component_arg = k.split(f"{component}__")
+            component_params[component_arg] = v
+    return component_params
+
+
+class ScienceEnsemble():
+    def __init__(self):
+        pass
+
+    def fit(self, X, Y):
+        # Implement now or later?
+        return self
+
+    def predict(self, X):
+        return self.model.predict(X)
+
+    def predict_proba(self, X):
+        # TODO: Replace with self.model.predict_proba(X) when implmented
+        Y_probs = np.array([
+            est.predict_proba(X) for est in self.estimators])
+        Y_prob = np.mean(Y_probs, axis=0)
+        return Y_prob
+
+    def save(self):
+        # Implement along with fit
+        pass
+
+    def _load(self, model_path):
+        # TODO: find out model from meta.json
+        if "tfidf_svm" in model_path:
+            with open(model_path, "rb") as f:
+                model = pickle.loads(f.read())
+            return model
+        elif "scibert" in model_path:
+            model = BertClassifier(pretrained="scibert")
+            model.load(model_path)
+            return model
+        else:
+            print(f"Did not recognise model in {model_path} to be one of tfidf-svm or scibert")
+            raise NotImplementedError
+
+    def load(self, model_paths):
+        self.estimators = []
+        for model_path in model_paths.split(","):
+            estimator = self._load(model_path)
+            self.estimators.append(estimator)
+        
+        self.model = WellcomeVotingClassifier(
+            estimators=self.estimators,
+            voting="soft",
+            multilabel=True
+        )
+
+
+class MeshCNN():
+    def __init__(self, threshold=0.5, batch_size=256, shuffle=True,
+            buffer_size=1000, data_cache=None, random_seed=42):
+        self.threshold = threshold
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.buffer_size = buffer_size
+        self.data_cache = data_cache
+        self.random_seed = random_seed
+
+    def _yield_data(self, X, vectorizer, Y=None):
+        """
+        Add docstring
+        """
+        def yield_transformed_data(X_buffer, Y_buffer):
+            Y_den = None
+            X_vec = self.vectorizer.transform(X_buffer)
+            if Y_buffer:
+                # Y_buffer list of np or sparse arrays
+                if type(Y_buffer[0]) == np.ndarray:
+                    Y_den = np.vstack(Y_buffer)
+                else: # sparse
+                    Y_buffer = sp.vstack(Y_buffer)
+                    Y_den = np.asarray(Y_buffer.todense())
+
+            for i in range(len(X_buffer)):
+                if Y_den is not None:
+                    yield X_vec[i], Y_den[i]
+                else:
+                    yield X_vec[i]
+
+        def data_gen():
+            X_buffer = []
+            Y_buffer = []
+
+            X_gen = X()
+            if Y:
+                Y_gen = Y()
+                data_zip = zip(X_gen, Y_gen)
+            else:
+                data_zip = X_gen
+            for data_example in data_zip:
+                if Y:
+                    x, y = data_example
+                    Y_buffer.append(y)
+                else:
+                    x = data_example
+                X_buffer.append(x)
+
+                if len(X_buffer) >= self.buffer_size:
+                    # Use yield from?
+                    for data_item in yield_transformed_data(X_buffer, Y_buffer):
+                        yield data_item
+
+                    X_buffer = []
+                    Y_buffer = []
+
+            if X_buffer:
+                # Use yield from?
+                for data_item in yield_transformed_data(X_buffer, Y_buffer):
+                    yield data_item
+
+        output_types = (tf.int32, tf.int32) if Y else (tf.int32)
+        data = tf.data.Dataset.from_generator(
+                data_gen, output_types=output_types)
+         
+        # Note we need to enable shuffling after every epoch in model
+        #   here we just shuffle once
+        #   possibly we should not shuffle at all here
+        if self.shuffle:
+            data = data.shuffle(self.buffer_size, seed=self.random_seed, reshuffle_each_iteration=False)
+        if self.data_cache:
+            data = data.cache(self.data_cache)
+        return data
+
+    def _init_model(self):
+        self.vectorizer = KerasVectorizer(
+                vocab_size=5_000, sequence_length=400)
+        self.classifier = CNNClassifier(
+                learning_rate=0.01, dropout=0.1, 
+                nb_epochs=20, nb_layers=4, multilabel=True,
+                threshold=self.threshold, batch_size=self.batch_size)
+    
+    def set_params(self, **params):
+        if not (hasattr(self, 'vectorizer') and hasattr(self, 'classifier')):
+            self._init_model()
+        vec_params = get_params_for_component(params, 'vec')
+        clf_params = get_params_for_component(params, 'cnn')
+        self.vectorizer.set_params(**vec_params)
+        self.classifier.set_params(**clf_params)
+
+    def fit(self, X, Y):
+        """
+        Add docstring
+        """
+        if not (hasattr(self, "vectorizer") and hasattr(self, "classifier")):
+            self._init_model()
+
+        if type(X) in [list, np.ndarray]:
+            print("Fitting vectorizer")
+            self.vectorizer.fit(X)
+            X_vec = self.vectorizer.transform(X)
+            print(X_vec.shape)
+            print("Fitting classifier")
+            self.classifier.fit(X_vec, Y)
+        else:
+            print("Fitting vectorizer")
+            X_gen = X()
+            self.vectorizer.fit(X_gen)
+            print("Fitting classifier")
+            # Need to pass in vocab size, sequence length and nb_outputs
+            # to classifier through set_params
+            train_data = self._yield_data(X, self.vectorizer, Y)
+            self.classifier.fit(train_data)
+            
+        return self
+ 
+    def predict(self, X):
+        if type(X) in [list, np.ndarray]:
+            X_vec = self.vectorizer.transform(X)
+            Y_pred = self.classifier.predict(X_vec)
+        else:
+            pred_data = self._yield_data(X, self.vectorizer)
+            Y_pred = self.classifier.predict(pred_data)
+        return Y_pred
+
+    def predict_proba(self, X):
+        # TODO: Should that be here or CNN, should it exist at all?
+        # what is the purpose, if Y is too large for memory whose
+        # responsibility is it?
+        if type(X) in [list, np.ndarray]:
+            X_vec = self.vectorizer.transform(X)
+            Y_pred_proba = []
+            for i in range(0, X_vec.shape[0], self.batch_size):
+                Y_pred_proba_batch = self.classifier.predict_proba(X_vec[i:i+self.batch_size])
+                Y_pred_proba.append(Y_pred_proba_batch)
+            Y_pred_proba = np.vstack(Y_pred_proba)
+        else:
+            pred_data = self._yield_data(X, self.vectorizer)
+            Y_pred_proba = self.classifier.predict_proba(pred_data)
+        return Y_pred_proba
+
+    def save(self, model_path):
+        if not os.path.exists(model_path):
+            os.mkdir(model_path)
+
+        vectorizer_path = os.path.join(model_path, "vectorizer.pkl")
+        with open(vectorizer_path, "wb") as f:
+            f.write(pickle.dumps(self.vectorizer))
+        self.classifier.save(model_path)
+
+    def load(self, model_path):
+        # TODO: Compare with tfidf load and consider adding meta 
+        vectorizer_path = os.path.join(model_path, "vectorizer.pkl")
+        with open(vectorizer_path, "rb") as f:
+            self.vectorizer = pickle.loads(f.read())
+        print(self.vectorizer.sequence_length)
+
+        # TODO: Use init?
+        self.classifier = CNNClassifier(
+            threshold = self.threshold,
+            multilabel = True
+        )
+        self.classifier.load(model_path)
+
+
+class MeshTfidfSVM():
+    def __init__(self, y_batch_size=256, nb_labels=None, model_path=None,
+            threshold=0.5):
+        self.y_batch_size=y_batch_size
+        self.model_path=model_path
+        self.nb_labels=None
+        self.threshold=threshold
+    
+    def _init_vectorizer(self):
+        self.vectorizer = TfidfVectorizer(
+            stop_words='english', max_df=0.95,
+            min_df=5, ngram_range=(1,1)
+        )
+
+    def _init_classifier(self):
+        self.classifier = OneVsRestClassifier(SGDClassifier(loss='hinge', penalty='l2'))
+
+    def set_params(self, **params):
+        if not hasattr(self, 'vectorizer'):
+            self._init_vectorizer()
+        if not hasattr(self, 'classifier'):
+            self._init_classifier()
+
+        vec_params = get_params_for_component(params, 'vec')
+        clf_params = get_params_for_component(params, 'clf')
+        self.vectorizer.set_params(**vec_params)
+        self.classifier.set_params(**clf_params)
+        # TODO: Generalise
+        if 'model_path' in params:
+            self.model_path = params['model_path']
+        if 'y_batch_size' in params:
+            self.y_batch_size = params['y_batch_size']
+        if 'nb_labels' in params:
+            self.nb_labels = params['nb_labels']
+
+    def fit(self, X, Y):
+        if not hasattr(self, 'vectorizer'):
+            self._init_vectorizer()
+        if not hasattr(self, 'classifier'):
+            self._init_classifier()
+
+        print(f"Creating {self.model_path}")
+        Path(self.model_path).mkdir(exist_ok=True)
+        print("Fitting vectorizer")
+        self.vectorizer.fit(X)
+        with open(f"{self.model_path}/vectorizer.pkl", "wb") as f:
+            f.write(pickle.dumps(self.vectorizer))
+        print("Training model")
+        self.nb_labels = Y.shape[1]
+        for tag_i in range(0, self.nb_labels, self.y_batch_size):
+            print(tag_i)
+            X_vec = self.vectorizer.transform(X)
+            self.classifier.fit(X_vec, Y[:,tag_i:tag_i+self.y_batch_size])
+            with open(f"{self.model_path}/{tag_i}.pkl", "wb") as f:
+                f.write(pickle.dumps(self.classifier))
+
+        return self
+
+    def _predict(self, X, return_probabilities=False): 
+        Y_pred = []
+        for tag_i in range(0, self.nb_labels, self.y_batch_size):
+            with open(f"{self.model_path}/{tag_i}.pkl", "rb") as f:
+                classifier = pickle.loads(f.read())
+            X_vec = self.vectorizer.transform(X)
+            if return_probabilities:
+                Y_pred_i = classifier.predict_proba(X_vec)
+            elif self.threshold != 0.5:
+                Y_pred_i = classifier.predict_proba(X_vec) > self.threshold
+                Y_pred_i = sp.csr_matrix(Y_pred_i)
+            else:
+                Y_pred_i = classifier.predict(X_vec)
+            Y_pred.append(Y_pred_i)
+
+        if return_probabilities:
+            Y_pred = np.hstack(Y_pred)
+        else:
+            Y_pred = sp.hstack(Y_pred)
+        return Y_pred
+
+    def predict(self, X):
+        return self._predict(X)
+
+    def predict_proba(self, X):
+        return self._predict(X, return_probabilities=True)
+
+    def save(self, model_path):
+        # model saved during fit
+        meta = {
+            "name": "MeshTfidfSVM",
+            "y_batch_size": self.y_batch_size,
+            "nb_labels": self.nb_labels
+        }
+        meta_path = os.path.join(model_path, "meta.json")
+        with open(meta_path, "w") as f:
+            f.write(json.dumps(meta))
+
+    def load(self, model_path):
+        vectorizer_path = os.path.join(model_path, "vectorizer.pkl")
+        with open(vectorizer_path, "rb") as f:
+            self.vectorizer = pickle.loads(f.read())
+
+        meta_path = os.path.join(model_path, "meta.json")
+        with open(meta_path, "r") as f:
+            meta = json.loads(f.read())
+        self.set_params(**meta)
+
+        self.model_path = model_path
+
+def create_model(approach, parameters=None):
+    if approach == 'tfidf-svm':
+        model = Pipeline([
+            ('tfidf', TfidfVectorizer(
+                stop_words='english', max_df=0.95,
+                min_df=0.0, ngram_range=(1,1)
+            )),
+            ('svm', OneVsRestClassifier(SVC(kernel='linear', probability=True)))
+        ])
+    elif approach == 'bert-svm':
+        model = Pipeline([
+            ('bert', BertVectorizer(pretrained='bert')),
+            ('svm', OneVsRestClassifier(SVC(kernel='linear', probability=True)))
+        ])
+    elif approach == 'scibert-svm':
+        model = Pipeline([
+            ('scibert', BertVectorizer(pretrained='scibert')),
+            ('svm', OneVsRestClassifier(SVC(kernel='linear', probability=True)))
+        ])
+    elif approach == 'spacy-textclassifier':
+        model = SpacyClassifier()
+    elif approach == 'bert':
+        model = BertClassifier()
+    elif approach == 'scibert':
+        model = BertClassifier(pretrained='scibert')
+    elif approach == 'classifierchain-tfidf-svm':
+        model = Pipeline([
+            ('tfidf', TfidfVectorizer(
+                stop_words='english', max_df=0.95,
+                min_df=0.0, ngram_range=(1,1)
+            )),
+            ('svm', ClassifierChain(classifier=SVC(kernel='linear', probability=True)))
+        ])
+    elif approach == 'labelpowerset-tfidf-svm':
+        model = Pipeline([
+            ('tfidf', TfidfVectorizer(
+                stop_words='english', max_df=0.95,
+                min_df=0.0, ngram_range=(1,1)
+            )),
+            ('svm', LabelPowerset(SVC(kernel='linear', probability=True)))
+        ])
+    elif approach == 'binaryrelevance-tfidf-svm':
+        # same as OneVsRestClassifier
+        model = Pipeline([
+            ('tfidf', TfidfVectorizer(
+                stop_words='english', max_df=0.95,
+                min_df=0.0, ngram_range=(1,1)
+            )),
+            ('svm', BinaryRelevance(classifier=SVC(kernel='linear', probability=True)))
+        ])
+    elif approach == 'binaryrelevance-tfidf-knn':
+        model = Pipeline([
+            ('tfidf', TfidfVectorizer(
+                stop_words='english', max_df=0.95,
+                min_df=0.0, ngram_range=(1,1)
+            )),
+            ('knn', BinaryRelevance(classifier=KNeighborsClassifier))
+        ])
+    elif approach == 'hashing_vectorizer-svm':
+        model = Pipeline([
+            ('hashing_vectorizer', HashingVectorizer()),
+            ('svm', OneVsRestClassifier(SGDClassifier(loss='hinge', penalty='l2')))
+        ])
+    elif approach == 'hashing_vectorizer-nb':
+        model = Pipeline([
+            ('hashing_vectorizer', HashingVectorizer(binary=True, n_features=2 ** 18)),
+            ('nb', OneVsRestClassifier(MultinomialNB()))
+        ])
+    elif approach == 'tfidf-sgd':
+        model = Pipeline([
+            ('tfidf', TfidfVectorizer(
+                stop_words='english', max_df=0.95,
+                min_df=5, ngram_range=(1,1)
+            )),
+            ('svm', OneVsRestClassifier(SGDClassifier(loss='hinge', penalty='l2')))
+        ])
+    elif approach == 'cnn':
+        model = Pipeline([
+            ('vec', KerasVectorizer(vocab_size=5_000)),
+            ('cnn', CNNClassifier(learning_rate=0.01, dropout=0.1, nb_epochs=20, nb_layers=4, multilabel=True))
+        ])
+    elif approach == 'bilstm':
+        model = Pipeline([
+            ('vec', KerasVectorizer(vocab_size=5_000, sequence_length=678)),
+            ('bilstm', BiLSTMClassifier(learning_rate=0.01, dropout=0.1, nb_epochs=20, multilabel=True))
+        ])
+    elif approach == 'doc2vec-sgd':
+        model = Pipeline([
+            ('vec', Doc2VecVectorizer()),
+            ('sgd', OneVsRestClassifier(SGDClassifier(penalty="l2", alpha=1e-8), n_jobs=-1))
+        ])
+    elif approach == 'doc2vec-tfidf-sgd':
+        model = Pipeline([
+            ('vec', FeatureUnion([
+                ('doc2vec', Pipeline([
+                    ('doc2vec_unscaled', Doc2VecVectorizer()),
+                    ('scale_doc2vec', Normalizer())
+                ])),
+                ('tfidf', Pipeline([
+                    ('tfidf_unscaled', TfidfVectorizer(min_df=5, stop_words='english', ngram_range=(1,2))),
+                    ('scale_tfidf', Normalizer())
+                ]))
+            ])),
+            ('sgd', OneVsRestClassifier(SGDClassifier(penalty="l2", alpha=1e-6), n_jobs=-1))
+        ])
+    elif approach == 'sent2vec-sgd':
+        model = Pipeline([
+            ('vec', Sent2VecVectorizer(pretrained="biosent2vec")),
+            ('sgd', OneVsRestClassifier(SGDClassifier(penalty="l2", alpha=1e-8), n_jobs=-1))
+        ])
+    elif approach == 'sent2vec-tfidf-sgd':
+        model = Pipeline([
+            ('vec', FeatureUnion([
+                ('sent2vec', Pipeline([
+                    ('sent2vec_unscaled', Sent2VecVectorizer(pretrained="biosent2vec")),
+                    ('scale_sent2vec', Normalizer())
+                ])),
+                ('tfidf', Pipeline([
+                    ('tfidf_unscaled', TfidfVectorizer(min_df=5, stop_words='english', ngram_range=(1,2))),
+                    ('scale_tfidf', Normalizer())
+                ]))
+            ])),
+            ('sgd', OneVsRestClassifier(SGDClassifier(penalty="l2", alpha=1e-8), n_jobs=-1))
+        ])
+    elif approach == 'tfidf-adaboost':
+        model = Pipeline([
+            ('tfidf', TfidfVectorizer(min_df=5, stop_words='english', ngram_range=(1,2))),
+            ('adaboost', OneVsRestClassifier(AdaBoostClassifier(DecisionTreeClassifier())))
+        ])
+    elif approach == 'tfidf-gboost':
+        model = Pipeline([
+            ('tfidf', TfidfVectorizer(min_df=5, stop_words='english', ngram_range=(1,2))),
+            ('gboost', OneVsRestClassifier(GradientBoostingClassifier()))
+        ])
+    elif approach == 'tfidf+onehot_team-svm':
+        model = Pipeline([
+            ('vectorizer', FeatureUnion([
+                ("text_features", Pipeline([
+                    ("selector", FunctionTransformer(lambda x: x["text"])),
+                    ("tfidf", TfidfVectorizer(min_df=5, ngram_range=(1,2), stop_words="english"))
+                ])),
+                ("team_features", Pipeline([
+                    ("selector", FunctionTransformer(lambda x: x[["Team"]])),
+                    ("one hot", OneHotEncoder(handle_unknown='ignore'))
+                ]))
+            ])),
+            ('svm', OneVsRestClassifier(SVC(class_weight="balanced", kernel="linear")))
+        ])
+    elif approach == 'tfidf+onehot_scheme-svm':
+        model = Pipeline([
+            ('vectorizer', FeatureUnion([
+                ("text_features", Pipeline([
+                    ("selector", FunctionTransformer(lambda x: x["text"])),
+                    ("tfidf", TfidfVectorizer(min_df=5, ngram_range=(1,2), stop_words="english"))
+                ])),
+                ("team_features", Pipeline([
+                    ("selector", FunctionTransformer(lambda x: x[["Scheme"]])),
+                    ("one hot", OneHotEncoder(handle_unknown='ignore'))
+                ]))
+            ])),
+            ('svm', OneVsRestClassifier(SVC(class_weight="balanced", kernel="linear")))
+        ])
+    elif approach == 'mesh-tfidf-svm':
+        model = MeshTfidfSVM()
+    elif approach == 'mesh-cnn':
+        model = MeshCNN()
+    else:
+        raise ApproachNotImplemented
+    if parameters:
+        params = ast.literal_eval(parameters)
+        model.set_params(**params)
+    else:
+        parameters = {}
+    return model

--- a/grants_tagger/predict.py
+++ b/grants_tagger/predict.py
@@ -20,9 +20,7 @@ DEFAULT_LABELBINARIZER_PATH = os.path.join(FILEPATH, '../models/label_binarizer.
 
 
 def predict(X_test, model_path, approach, threshold=0.5, return_probabilities=False):
-    # TODO: Use create model and limit approaches to production models
     if approach == 'mesh-cnn':
-        # TODO: pass params
         model = MeshCNN(
             threshold=threshold
         )

--- a/grants_tagger/predict.py
+++ b/grants_tagger/predict.py
@@ -40,7 +40,7 @@ def predict(X_test, model_path, approach, threshold=0.5, return_probabilities=Fa
     else:
         return model.predict(X_test)
 
-
+# TODO: Is y_batch_size needed?
 def predict_tags(
         X, model_path, label_binarizer_path,
         approach, probabilities=False,
@@ -48,10 +48,12 @@ def predict_tags(
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
 
+    # TODO: Remove?
     nb_labels = len(label_binarizer.classes_)
 
     Y_pred_proba = predict(X, model_path, threshold=threshold, return_probabilities=True, approach=approach)
 
+    # TODO: Now that all models accept threshold, is that needed?
     tags = []
     for y_pred_proba in Y_pred_proba:
         if probabilities:

--- a/grants_tagger/predict.py
+++ b/grants_tagger/predict.py
@@ -40,18 +40,15 @@ def predict(X_test, model_path, approach, threshold=0.5, return_probabilities=Fa
     else:
         return model.predict(X_test)
 
-# TODO: Is y_batch_size needed?
 def predict_tags(
         X, model_path, label_binarizer_path,
         approach, probabilities=False,
-        threshold=0.5, y_batch_size=512):
+        threshold=0.5):
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
 
-    # TODO: Remove?
-    nb_labels = len(label_binarizer.classes_)
-
-    Y_pred_proba = predict(X, model_path, threshold=threshold, return_probabilities=True, approach=approach)
+    Y_pred_proba = predict(X, model_path, threshold=threshold,
+        return_probabilities=True, approach=approach)
 
     # TODO: Now that all models accept threshold, is that needed?
     tags = []

--- a/grants_tagger/predict.py
+++ b/grants_tagger/predict.py
@@ -44,6 +44,14 @@ def predict_tags(
         X, model_path, label_binarizer_path,
         approach, probabilities=False,
         threshold=0.5):
+    """
+    X: list or numpy array of texts
+    model_path: path to trained model
+    label_binarizer_path: path to trained label_binarizer
+    approach: approach used to train the model
+    probabilities: bool, default False. When true probabilities are returned along with tags
+    threshold: float, default 0.5. Probability threshold to be used to assign tags.
+    """
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
 

--- a/grants_tagger/predict.py
+++ b/grants_tagger/predict.py
@@ -9,11 +9,9 @@ import argparse
 import pickle
 import os
 
-from wellcomeml.ml.bert_classifier import BertClassifier
-from wellcomeml.ml import CNNClassifier
-from numpy import hstack, vstack
-from scipy.sparse import hstack as sparse_hstack, csr_matrix
 import numpy as np
+
+from grants_tagger.models import MeshCNN, MeshTfidfSVM, ScienceEnsemble 
 
 FILEPATH = os.path.dirname(__file__)
 DEFAULT_SCIBERT_PATH = os.path.join(FILEPATH, '../models/scibert-2020.05.5')
@@ -21,109 +19,40 @@ DEFAULT_TFIDF_SVM_PATH = os.path.join(FILEPATH, '../models/tfidf-svm-2020.05.2.p
 DEFAULT_LABELBINARIZER_PATH = os.path.join(FILEPATH, '../models/label_binarizer.pkl')
 
 
-def load_model(model_path):
-    if str(model_path).endswith('.pkl'):
-        with open(model_path, "rb") as f:
-            model = pickle.loads(f.read())
-            return model
-    if 'scibert' in model_path:
-        scibert = BertClassifier(pretrained="scibert")
-        scibert.load(model_path)
-        return scibert
-    raise NotImplementedError
-
-
-def predict_proba_ensemble_tfidf_svm_bert(X, model_paths):
-    Y_pred_proba = []
-    for model_path in model_paths:
-        model = load_model(model_path)
-        Y_pred_proba_model = model.predict_proba(X)
-        Y_pred_proba.append(Y_pred_proba_model)
-
-    Y_pred_proba = np.array(Y_pred_proba).sum(axis=0) / len(model_paths)
-    return Y_pred_proba
-
-
-def predict_tfidf_svm(X, model_path, nb_labels, threshold=0.5,
-                      return_probabilities=True, y_batch_size=512):
-    # TODO: generalise tfidf to vectorizer.pkl
-    with open(f"{model_path}/tfidf.pkl", "rb") as f:
-        vectorizer = pickle.loads(f.read())
-
-    X_vec = vectorizer.transform(X)
-
-    Y_pred = []
-    for tag_i in range(0, nb_labels, y_batch_size):
-        with open(f"{model_path}/{tag_i}.pkl", "rb") as f:
-            classifier = pickle.loads(f.read())
-        if return_probabilities:
-            Y_pred_i = classifier.predict_proba(X_vec)
-        elif threshold != 0.5:
-            Y_pred_i = classifier.predict_proba(X_vec)
-            Y_pred_i = csr_matrix(Y_pred_i > threshold)
-        else:
-            Y_pred_i = classifier.predict(X_vec)
-        Y_pred.append(Y_pred_i)
-
-    if return_probabilities:
-        Y_pred = hstack(Y_pred)
+def predict(X_test, model_path, approach, threshold=0.5, return_probabilities=False):
+    # TODO: Use create model and limit approaches to production models
+    if approach == 'mesh-cnn':
+        # TODO: pass params
+        model = MeshCNN(
+            threshold=threshold
+        )
+    elif approach == 'mesh-tfidf-svm':
+        model = MeshTfidfSVM(
+            threshold=threshold,
+        )
+    elif approach == 'science-ensemble':
+        model = ScienceEnsemble()
     else:
-        Y_pred = sparse_hstack(Y_pred)
-    return Y_pred
+        raise NotImplementedError
 
-
-def predict_cnn(X, model_path, threshold=0.5,
-                return_probabilities=False, x_batch_size=512):
-    with open(f"{model_path}/vectorizer.pkl", "rb") as f:
-        vectorizer = pickle.loads(f.read())
-    model = CNNClassifier(
-        sparse_y=True, threshold=threshold, batch_size=x_batch_size
-    )
     model.load(model_path)
 
-    X_vec = vectorizer.transform(X)
     if return_probabilities:
-        Y_pred_proba = []
-        for i in range(0, X_vec.shape[0], x_batch_size):
-            Y_pred_proba_batch = model.predict_proba(X_vec[i:i+x_batch_size])
-            Y_pred_proba.append(Y_pred_proba_batch)
-        Y_pred_proba = vstack(Y_pred_proba)
-        return Y_pred_proba
+        return model.predict_proba(X_test)
     else:
-        Y_pred = model.predict(X_vec)
-        return Y_pred
+        return model.predict(X_test)
 
 
-def predict(X_test, model_path, nb_labels=None, threshold=0.5, return_probabilities=False):
-    if type(model_path) == list:
-        Y_pred_proba = predict_proba_ensemble_tfidf_svm_bert(X_test, model_path)
-        if return_probabilities:
-            Y_pred = Y_pred_proba
-        else:
-            Y_pred = Y_pred_proba > threshold
-    elif "disease_mesh_cnn" in str(model_path):
-        Y_pred = predict_cnn(X_test, model_path, threshold, return_probabilities)
-    elif "disease_mesh_tfidf" in str(model_path):
-        Y_pred = predict_tfidf_svm(X_test, model_path, nb_labels, threshold, return_probabilities)
-    else:
-        model = load_model(model_path)
-        Y_pred_proba = model.predict_proba(X_test)
-        if return_probabilities:
-            Y_pred = Y_pred_proba
-        else:
-            Y_pred = Y_pred_proba > threshold
-    return Y_pred
-
-
-def predict_tags(X, model_path, label_binarizer_path,
-                 probabilities=False, threshold=0.5,
-                 y_batch_size=512):
+def predict_tags(
+        X, model_path, label_binarizer_path,
+        approach, probabilities=False,
+        threshold=0.5, y_batch_size=512):
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
 
     nb_labels = len(label_binarizer.classes_)
 
-    Y_pred_proba = predict(X, model_path, threshold=threshold, return_probabilities=True, nb_labels=nb_labels)
+    Y_pred_proba = predict(X, model_path, threshold=threshold, return_probabilities=True, approach=approach)
 
     tags = []
     for y_pred_proba in Y_pred_proba:

--- a/grants_tagger/tag_grants.py
+++ b/grants_tagger/tag_grants.py
@@ -25,7 +25,7 @@ def yield_grants(grants_path, batch_size=32):
             yield grants
 
 
-def yield_tagged_grants(grants, model_path, label_binarizer_path, threshold):
+def yield_tagged_grants(grants, model_path, label_binarizer_path, approach, threshold):
     """
     Tags grants and outputs tagged grant data structure
 
@@ -40,6 +40,7 @@ def yield_tagged_grants(grants, model_path, label_binarizer_path, threshold):
     grants_tags = predict_tags(
         grants_texts,
         threshold=threshold,
+        approach=approach,
         model_path=model_path,
         label_binarizer_path=label_binarizer_path
     )
@@ -57,7 +58,7 @@ def yield_tagged_grants(grants, model_path, label_binarizer_path, threshold):
         yield tagged_grant
 
 
-def tag_grants(grants_path, tagged_grants_path, model_path, label_binarizer_path, threshold=0.5):
+def tag_grants(grants_path, tagged_grants_path, model_path, label_binarizer_path, approach, threshold=0.5):
     with open(tagged_grants_path, 'w') as f_o:
         fieldnames = ["Grant ID", "Reference", "Grant No."]
         fieldnames += [f"Tag #{i}" for i in range(1,11)]
@@ -65,5 +66,5 @@ def tag_grants(grants_path, tagged_grants_path, model_path, label_binarizer_path
         csv_writer.writeheader()
 
         for grants in yield_grants(grants_path, batch_size=512):
-            for tagged_grant in yield_tagged_grants(grants, model_path, label_binarizer_path, threshold):
+            for tagged_grant in yield_tagged_grants(grants, model_path, label_binarizer_path, approach, threshold):
                 csv_writer.writerow(tagged_grant)

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -2,22 +2,6 @@
 """
 Train a spacy or sklearn model and pickle it
 """
-from skmultilearn.problem_transform import ClassifierChain, LabelPowerset, BinaryRelevance
-from skmultilearn.adapt import BRkNNaClassifier, MLkNN
-from sklearn.preprocessing import MultiLabelBinarizer
-from sklearn.ensemble import AdaBoostClassifier
-from sklearn.multiclass import OneVsRestClassifier
-from sklearn.feature_selection import SelectFromModel
-from sklearn.pipeline import Pipeline, FeatureUnion
-from sklearn.metrics import f1_score, precision_score, recall_score, classification_report
-from sklearn.feature_extraction.text import TfidfVectorizer, HashingVectorizer
-from sklearn.svm import SVC
-from sklearn.tree import DecisionTreeClassifier
-from sklearn.neighbors import KNeighborsClassifier
-from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
-from sklearn.linear_model import SGDClassifier
-from sklearn.naive_bayes import MultinomialNB
-from sklearn.preprocessing import Normalizer, OneHotEncoder, FunctionTransformer
 from scipy import sparse as sp
 import numpy as np
 
@@ -27,203 +11,28 @@ import os.path
 import json
 import ast
 
-from wellcomeml.ml import BiLSTMClassifier, CNNClassifier, KerasVectorizer, SpacyClassifier, BertVectorizer, BertClassifier, Doc2VecVectorizer, Sent2VecVectorizer
-from grants_tagger.utils import load_train_test_data, yield_texts, yield_tags, load_train_test_dataset
+from sklearn.metrics import f1_score, classification_report
+from sklearn.preprocessing import MultiLabelBinarizer
 
-
-class ApproachNotImplemented(Exception):
-    pass
+from grants_tagger.models import create_model
+from grants_tagger.utils import load_train_test_data, yield_tags
 
 
 def create_label_binarizer(data_path, label_binarizer_path, sparse=False):        
     label_binarizer = MultiLabelBinarizer(sparse_output=sparse)
+    # TODO: pass Y_train here which can be generator or list
     label_binarizer.fit(yield_tags(data_path))
+
     with open(label_binarizer_path, 'wb') as f:
-        pickle.dump(label_binarizer, f)
+        f.write(pickle.dumps(label_binarizer))
 
     return label_binarizer
-
-
-def create_model(approach, parameters=None):
-    if approach == 'tfidf-svm':
-        model = Pipeline([
-            ('tfidf', TfidfVectorizer(
-                stop_words='english', max_df=0.95,
-                min_df=0.0, ngram_range=(1,1)
-            )),
-            ('svm', OneVsRestClassifier(SVC(kernel='linear', probability=True)))
-        ])
-    elif approach == 'bert-svm':
-        model = Pipeline([
-            ('bert', BertVectorizer(pretrained='bert')),
-            ('svm', OneVsRestClassifier(SVC(kernel='linear', probability=True)))
-        ])
-    elif approach == 'scibert-svm':
-        model = Pipeline([
-            ('scibert', BertVectorizer(pretrained='scibert')),
-            ('svm', OneVsRestClassifier(SVC(kernel='linear', probability=True)))
-        ])
-    elif approach == 'spacy-textclassifier':
-        model = SpacyClassifier()
-    elif approach == 'bert':
-        model = BertClassifier()
-    elif approach == 'scibert':
-        model = BertClassifier(pretrained='scibert')
-    elif approach == 'classifierchain-tfidf-svm':
-        model = Pipeline([
-            ('tfidf', TfidfVectorizer(
-                stop_words='english', max_df=0.95,
-                min_df=0.0, ngram_range=(1,1)
-            )),
-            ('svm', ClassifierChain(classifier=SVC(kernel='linear', probability=True)))
-        ])
-    elif approach == 'labelpowerset-tfidf-svm':
-        model = Pipeline([
-            ('tfidf', TfidfVectorizer(
-                stop_words='english', max_df=0.95,
-                min_df=0.0, ngram_range=(1,1)
-            )),
-            ('svm', LabelPowerset(SVC(kernel='linear', probability=True)))
-        ])
-    elif approach == 'binaryrelevance-tfidf-svm':
-        # same as OneVsRestClassifier
-        model = Pipeline([
-            ('tfidf', TfidfVectorizer(
-                stop_words='english', max_df=0.95,
-                min_df=0.0, ngram_range=(1,1)
-            )),
-            ('svm', BinaryRelevance(classifier=SVC(kernel='linear', probability=True)))
-        ])
-    elif approach == 'binaryrelevance-tfidf-knn':
-        model = Pipeline([
-            ('tfidf', TfidfVectorizer(
-                stop_words='english', max_df=0.95,
-                min_df=0.0, ngram_range=(1,1)
-            )),
-            ('knn', BinaryRelevance(classifier=KNeighborsClassifier))
-        ])
-    elif approach == 'hashing_vectorizer-svm':
-        model = Pipeline([
-            ('hashing_vectorizer', HashingVectorizer()),
-            ('svm', OneVsRestClassifier(SGDClassifier(loss='hinge', penalty='l2')))
-        ])
-    elif approach == 'hashing_vectorizer-nb':
-        model = Pipeline([
-            ('hashing_vectorizer', HashingVectorizer(binary=True, n_features=2 ** 18)),
-            ('nb', OneVsRestClassifier(MultinomialNB()))
-        ])
-    elif approach == 'tfidf-sgd':
-        model = Pipeline([
-            ('tfidf', TfidfVectorizer(
-                stop_words='english', max_df=0.95,
-                min_df=5, ngram_range=(1,1)
-            )),
-            ('svm', OneVsRestClassifier(SGDClassifier(loss='hinge', penalty='l2')))
-        ])
-    elif approach == 'cnn':
-        model = Pipeline([
-            ('vec', KerasVectorizer(vocab_size=5_000)),
-            ('cnn', CNNClassifier(learning_rate=0.01, dropout=0.1, nb_epochs=20, nb_layers=4, multilabel=True))
-        ])
-    elif approach == 'bilstm':
-        model = Pipeline([
-            ('vec', KerasVectorizer(vocab_size=5_000, sequence_length=678)),
-            ('bilstm', BiLSTMClassifier(learning_rate=0.01, dropout=0.1, nb_epochs=20, multilabel=True))
-        ])
-    elif approach == 'doc2vec-sgd':
-        model = Pipeline([
-            ('vec', Doc2VecVectorizer()),
-            ('sgd', OneVsRestClassifier(SGDClassifier(penalty="l2", alpha=1e-8), n_jobs=-1))
-        ])
-    elif approach == 'doc2vec-tfidf-sgd':
-        model = Pipeline([
-            ('vec', FeatureUnion([
-                ('doc2vec', Pipeline([
-                    ('doc2vec_unscaled', Doc2VecVectorizer()),
-                    ('scale_doc2vec', Normalizer())
-                ])),
-                ('tfidf', Pipeline([
-                    ('tfidf_unscaled', TfidfVectorizer(min_df=5, stop_words='english', ngram_range=(1,2))),
-                    ('scale_tfidf', Normalizer())
-                ]))
-            ])),
-            ('sgd', OneVsRestClassifier(SGDClassifier(penalty="l2", alpha=1e-6), n_jobs=-1))
-        ])
-    elif approach == 'sent2vec-sgd':
-        model = Pipeline([
-            ('vec', Sent2VecVectorizer(pretrained="biosent2vec")),
-            ('sgd', OneVsRestClassifier(SGDClassifier(penalty="l2", alpha=1e-8), n_jobs=-1))
-        ])
-    elif approach == 'sent2vec-tfidf-sgd':
-        model = Pipeline([
-            ('vec', FeatureUnion([
-                ('sent2vec', Pipeline([
-                    ('sent2vec_unscaled', Sent2VecVectorizer(pretrained="biosent2vec")),
-                    ('scale_sent2vec', Normalizer())
-                ])),
-                ('tfidf', Pipeline([
-                    ('tfidf_unscaled', TfidfVectorizer(min_df=5, stop_words='english', ngram_range=(1,2))),
-                    ('scale_tfidf', Normalizer())
-                ]))
-            ])),
-            ('sgd', OneVsRestClassifier(SGDClassifier(penalty="l2", alpha=1e-8), n_jobs=-1))
-        ])
-    elif approach == 'tfidf-adaboost':
-        model = Pipeline([
-            ('tfidf', TfidfVectorizer(min_df=5, stop_words='english', ngram_range=(1,2))),
-            ('adaboost', OneVsRestClassifier(AdaBoostClassifier(DecisionTreeClassifier())))
-        ])
-    elif approach == 'tfidf-gboost':
-        model = Pipeline([
-            ('tfidf', TfidfVectorizer(min_df=5, stop_words='english', ngram_range=(1,2))),
-            ('gboost', OneVsRestClassifier(GradientBoostingClassifier()))
-        ])
-    elif approach == 'tfidf+onehot_team-svm':
-        model = Pipeline([
-            ('vectorizer', FeatureUnion([
-                ("text_features", Pipeline([
-                    ("selector", FunctionTransformer(lambda x: x["text"])),
-                    ("tfidf", TfidfVectorizer(min_df=5, ngram_range=(1,2), stop_words="english"))
-                ])),
-                ("team_features", Pipeline([
-                    ("selector", FunctionTransformer(lambda x: x[["Team"]])),
-                    ("one hot", OneHotEncoder(handle_unknown='ignore'))
-                ]))
-            ])),
-            ('svm', OneVsRestClassifier(SVC(class_weight="balanced", kernel="linear")))
-        ])
-    elif approach == 'tfidf+onehot_scheme-svm':
-        model = Pipeline([
-            ('vectorizer', FeatureUnion([
-                ("text_features", Pipeline([
-                    ("selector", FunctionTransformer(lambda x: x["text"])),
-                    ("tfidf", TfidfVectorizer(min_df=5, ngram_range=(1,2), stop_words="english"))
-                ])),
-                ("team_features", Pipeline([
-                    ("selector", FunctionTransformer(lambda x: x[["Scheme"]])),
-                    ("one hot", OneHotEncoder(handle_unknown='ignore'))
-                ]))
-            ])),
-            ('svm', OneVsRestClassifier(SVC(class_weight="balanced", kernel="linear")))
-        ])
-    else:
-        raise ApproachNotImplemented
-    if parameters:
-        params = ast.literal_eval(parameters)
-        model.set_params(**params)
-    else:
-        parameters = {}
-    return model
-
 
 def train_and_evaluate(
         train_data_path, label_binarizer_path, approach,
         parameters=None, model_path=None, test_data_path=None,
-        incremental_learning=False, nb_epochs=5,
-        from_same_distribution=False, threshold=None,
-        y_batch_size=None, X_format="List",
-        test_size=0.25, sparse_labels=False,
-        cache_path=None, verbose=True):
+        threshold=None, test_size=0.25, sparse_labels=False,
+        cache_path=None, data_format="list", verbose=True):
 
     if os.path.exists(label_binarizer_path):
         print(f"{label_binarizer_path} exists. Loading existing")
@@ -236,116 +45,43 @@ def train_and_evaluate(
     # so that run experiments can pass a model here
     model = create_model(approach, parameters)
 
-    if incremental_learning:
-        if approach in ["cnn", "bilstm"]:
-            vectorizer = model.steps[0][1]
-            classifier = model.steps[1][1]
+    # X can be (numpy arrays, lists) or generators
+    X_train, X_test, Y_train, Y_test = load_train_test_data(
+        train_data_path, label_binarizer, test_data_path=test_data_path,
+        test_size=test_size, data_format=data_format)
+    model.fit(X_train, Y_train)
 
-            # Note that we fit the vectorizer using all data. See Issue#59.
-            print("Fitting vectorizer")
-            vectorizer.fit(yield_texts(train_data_path))
-            print("Fitting classifier")
-            train_data, test_data = load_train_test_dataset(
-                train_data_path, vectorizer, label_binarizer,
-                test_data_path=test_data_path, sparse_labels=sparse_labels,
-                test_size=test_size, data_cache=cache_path
-            )
-            classifier.fit(train_data)
+    # This should be handled somewhere else?
+    if data_format == "generator":
+        Y_test_gen = Y_test()
+        if sparse_labels:
+            Y_test_batches = []
+            for Y_test_batch in Y_test_gen:
+                Y_test_batch = sp.csr_matrix(Y_test_batch)
+                Y_test_batches.append(Y_test_batch)
+            Y_test = sp.vstack(Y_test_batches)
         else:
-            # OneVsRestClassifier does not work with partial fit
-            # TODO: fit one SGDClassifier per label, use multiprocessing
-            raise NotImplementedError
-    else:
-        X_train, X_test, Y_train, Y_test = load_train_test_data(
-            train_data_path=train_data_path,
-            test_data_path=test_data_path,
-            label_binarizer=label_binarizer,
-            from_same_distribution=from_same_distribution,
-            X_format=X_format,
-            test_size=test_size
-        )
-        if y_batch_size:
-            vectorizer = model.steps[0][1]
-            classifier = model.steps[1][1]
-
-            Path(model_path).mkdir(exist_ok=True)
-            print("Fitting vectorizer")
-            vectorizer.fit(X_train)
-            with open(f"{model_path}/vectorizer.pkl", "wb") as f:
-                f.write(pickle.dumps(vectorizer))
-            print("Training model")
-            for tag_i in range(0, Y_train.shape[1], y_batch_size):
-                print(tag_i)
-                X_train_vec = vectorizer.transform(X_train)
-                classifier.fit(X_train_vec, Y_train[:,tag_i:tag_i+y_batch_size]) # assuming that fit clears previous params
-                with open(f"{model_path}/{tag_i}.pkl", "wb") as f:
-                    f.write(pickle.dumps(classifier))
-        else:
-            model.fit(X_train, Y_train)
-
+            Y_test = list(Y_test_gen)
+    
+    # TODO: Use evaluation from predict or evaluate
     if threshold:
-        if y_batch_size:
-            pass # to be implemented
-        else:
-            Y_pred_prob = model.predict_proba(X_test)
+        Y_pred_prob = model.predict_proba(X_test)
         Y_pred_test = Y_pred_prob > threshold
     else:
-        if incremental_learning:
-            if approach in ["cnn", "bilstm"]:
-                if sparse_labels:
-                    Y_test = []
-                    for _, Y_batch in test_data:
-                        Y_batch = sp.csr_matrix(Y_batch.numpy())
-                        Y_test.append(Y_batch)
-                    Y_test = sp.vstack(Y_test)
-                else:
-                    Y_test = []
-                    for _, Y_batch in test_data:
-                        Y_test.append(Y_batch)
-                    Y_test = np.vstack(Y_test)
-                Y_pred_test = classifier.predict(test_data)
-            else:
-                raise NotImplementedError
-        elif y_batch_size:
-            Y_pred_test = []
-            for tag_i in range(0, Y_test.shape[1], y_batch_size):
-                with open(f"{model_path}/{tag_i}.pkl", "rb") as f:
-                    classifier = pickle.loads(f.read())
-                X_test_vec = vectorizer.transform(X_test)
-                Y_pred_test_i = classifier.predict(X_test_vec)
-                Y_pred_test.append(Y_pred_test_i)
-                print(Y_pred_test_i.shape)
-            Y_pred_test = sp.hstack(Y_pred_test)
-        else:
-            Y_pred_test = model.predict(X_test)
-            # Y_pred_train = model.predict(X_train)
+        Y_pred_test = model.predict(X_test)
+
+    Y_pred_test = sp.csr_matrix(Y_pred_test)
 
     f1 = f1_score(Y_test, Y_pred_test, average='micro')
-    if verbose:
-        report = classification_report(Y_test, Y_pred_test, target_names=label_binarizer.classes_)
-        print(report)
+#    if verbose:
+#        report = classification_report(Y_test, Y_pred_test, target_names=label_binarizer.classes_)
+#        print(report)
 
     if model_path:
         if str(model_path).endswith('pkl') or str(model_path).endswith('pickle'):
             with open(model_path, 'wb') as f:
-                pickle.dump(model, f)
-        elif y_batch_size: 
-            pass # saved already
-        else: # dir path that might not exist
-            if not os.path.exists(model_path):
-                os.mkdir(model_path)
-            if approach in ["cnn", "bilstm"]:
-                # cnn and bilstm are pipelines so do not have a save
-                # but CNNClassifier and BiLSTMClassifier do have one
-                vectorizer = model.steps[0][1]
-                classifier = model.steps[1][1]
-
-                vectorizer_path = os.path.join(model_path, "vectorizer.pkl")
-                with open(vectorizer_path, "wb") as f:
-                    f.write(pickle.dumps(vectorizer))
-                classifier.save(model_path)
-
-            else: # default behaviour assumes that model has a save if path given
-                model.save(model_path)
-
+                f.write(pickle.dumps(model))
+        else:
+            model.save(model_path)
+    
     return f1

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -41,8 +41,6 @@ def train_and_evaluate(
     else:
         label_binarizer = create_label_binarizer(train_data_path, label_binarizer_path, sparse_labels)
 
-    # model creation from approach could move outside this function
-    # so that run experiments can pass a model here
     model = create_model(approach, parameters)
 
     # X can be (numpy arrays, lists) or generators
@@ -51,7 +49,7 @@ def train_and_evaluate(
         test_size=test_size, data_format=data_format)
     model.fit(X_train, Y_train)
 
-    # This should be handled somewhere else?
+    # TODO: Can we handle it better?
     if data_format == "generator":
         Y_test_gen = Y_test()
         if sparse_labels:
@@ -63,19 +61,16 @@ def train_and_evaluate(
         else:
             Y_test = list(Y_test_gen)
     
-    # TODO: Use evaluation from predict or evaluate
     if threshold:
         Y_pred_prob = model.predict_proba(X_test)
         Y_pred_test = Y_pred_prob > threshold
     else:
         Y_pred_test = model.predict(X_test)
 
-    Y_pred_test = sp.csr_matrix(Y_pred_test)
-
     f1 = f1_score(Y_test, Y_pred_test, average='micro')
-#    if verbose:
-#        report = classification_report(Y_test, Y_pred_test, target_names=label_binarizer.classes_)
-#        print(report)
+    if verbose:
+        report = classification_report(Y_test, Y_pred_test, target_names=label_binarizer.classes_)
+        print(report)
 
     if model_path:
         if str(model_path).endswith('pkl') or str(model_path).endswith('pickle'):

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -19,6 +19,7 @@ from grants_tagger.utils import load_train_test_data, yield_tags
 
 
 def create_label_binarizer(data_path, label_binarizer_path, sparse=False):        
+    """Creates, saves and returns a multilabel binarizer for targets Y"""
     label_binarizer = MultiLabelBinarizer(sparse_output=sparse)
     # TODO: pass Y_train here which can be generator or list
     label_binarizer.fit(yield_tags(data_path))
@@ -33,6 +34,19 @@ def train_and_evaluate(
         parameters=None, model_path=None, test_data_path=None,
         threshold=None, test_size=0.25, sparse_labels=False,
         cache_path=None, data_format="list", verbose=True):
+    """
+    train_data_path: path. path to JSONL data that contains "text" and "tags" fields.
+    label_binarizer_path: path. path to load or store label_binarizer.
+    approach: str. approach to use for modelling e.g. tfidf-svm or bert.
+    parameters: str. a stringified dict that contains params that get passed to the model.
+    model_path: path. path to save the model.
+    test_data_path: path, default None. path to test data, if not provided train data would be split.
+    threshold: float, default 0.5. Probability on top of which a tag is assigned.
+    test_size: float, default 0.25. when test_data_path not provided this is the split used for test data
+    sparse_labels: bool, default False. whether tags (labels) would be sparse for memory efficiency.
+    cache_path: path, default None. path to use for caching data transformations for speed.
+    data_format: str, default list. one of list, generator. generator used for memory efficiency.
+    """
 
     if os.path.exists(label_binarizer_path):
         print(f"{label_binarizer_path} exists. Loading existing")

--- a/grants_tagger/tune_threshold.py
+++ b/grants_tagger/tune_threshold.py
@@ -94,9 +94,7 @@ def tune_threshold(approach, data_path, model_path, label_binarizer_path, thresh
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
 
-    # TODO: Same as evaluate_model
     _, X_test, _, Y_test = load_train_test_data(data_path, label_binarizer)
-    print(X_test)
     if not sample_size:
         sample_size = Y_test.shape[0]
 

--- a/grants_tagger/tune_threshold.py
+++ b/grants_tagger/tune_threshold.py
@@ -90,12 +90,13 @@ def optimise_threshold(Y_test, Y_pred_proba, nb_thresholds=None, init_threshold=
     return optimal_thresholds
 
 
-def tune_threshold(data_path, model_path, label_binarizer_path, thresholds_path, sample_size=None, nb_thresholds=None, init_threshold=None):
+def tune_threshold(approach, data_path, model_path, label_binarizer_path, thresholds_path, sample_size=None, nb_thresholds=None, init_threshold=None):
     with open(label_binarizer_path, "rb") as f:
         label_binarizer = pickle.loads(f.read())
 
+    # TODO: Same as evaluate_model
     _, X_test, _, Y_test = load_train_test_data(data_path, label_binarizer)
-
+    print(X_test)
     if not sample_size:
         sample_size = Y_test.shape[0]
 
@@ -105,11 +106,11 @@ def tune_threshold(data_path, model_path, label_binarizer_path, thresholds_path,
     X_test_sample = X_test[sample_indices]
     Y_test_sample = Y_test[sample_indices, :]
 
-    Y_pred_proba = predict(X_test_sample, model_path, return_probabilities=True)
+    Y_pred_proba = predict(X_test_sample, model_path, approach, return_probabilities=True)
 
     optimal_thresholds = optimise_threshold(Y_test_sample, Y_pred_proba, nb_thresholds, init_threshold)
 
-    Y_pred = predict(X_test, model_path, threshold=optimal_thresholds)
+    Y_pred = predict(X_test, model_path, approach, threshold=optimal_thresholds)
     
     optimal_f1 = f1_score(Y_test, Y_pred, average="micro")
     print("---Optimal f1---")

--- a/grants_tagger/utils.py
+++ b/grants_tagger/utils.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+from functools import partial
 import pickle
 import json
 
@@ -32,29 +33,48 @@ def load_data(data_path, label_binarizer=None, X_format="List"):
         return X, tags, meta
 
     return texts, tags, meta
+ 
+def yield_texts(data_path):
+    with open(data_path) as f:
+        for line in f:
+            item = json.loads(line)
+            yield item["text"]
+
+def yield_tags(data_path, label_binarizer=None):
+    with open(data_path) as f:
+        for line in f:
+            item = json.loads(line)
+            
+            if label_binarizer:
+                # TODO: Make more efficient by using a buffer
+                yield label_binarizer.transform([item["tags"]])[0]
+            else:
+                yield item["tags"]
 
 def load_train_test_data(
-        train_data_path, label_binarizer,
-        test_data_path=None, from_same_distribution=False,
-        X_format="List", test_size=None):
+        train_data_path, label_binarizer, test_data_path=None,
+        test_size=None, data_format="list"):
 
-    if test_data_path:
-        X_train, Y_train, _ = load_data(train_data_path, label_binarizer, X_format)
-        X_test, Y_test, _ = load_data(test_data_path, label_binarizer, X_format)
+    if data_format == "list":
+        if test_data_path:
+            X_train, Y_train, _ = load_data(train_data_path, label_binarizer)
+            X_test, Y_test, _ = load_data(test_data_path, label_binarizer)
 
-        if from_same_distribution:
-            X_train, _, Y_train, _ = train_test_split(
-                X_train, Y_train, random_state=42
-            )
-            _, X_test, _, Y_test = train_test_split(
-                X_test, Y_test, random_state=42
+        else:
+            X, Y, _ = load_data(train_data_path, label_binarizer)
+            X_train, X_test, Y_train, Y_test = train_test_split(
+                X, Y, random_state=42, test_size=test_size
             )
     else:
-        X, Y, _ = load_data(train_data_path, label_binarizer, X_format)
-        X_train, X_test, Y_train, Y_test = train_test_split(
-            X, Y, random_state=42, test_size=test_size
-        )
-           
+        if test_data_path:
+            X_train = partial(yield_texts, train_data_path)
+            Y_train = partial(yield_tags, train_data_path, label_binarizer)
+            X_test = partial(yield_texts, test_data_path)
+            Y_test = partial(yield_tags, test_data_path, label_binarizer)
+        else:
+            # need to split train / test and shuffle in memory efficient way
+            raise NotImplementedError
+
     return X_train, X_test, Y_train, Y_test
 
 # TODO: Move to common for cases where Y is a matrix
@@ -68,85 +88,3 @@ def calc_performance_per_tag(Y_true, Y_pred, tags):
             'f1': f1_score(y_true_tag, y_pred_tag)
         })
     return pd.DataFrame(metrics)
-
-def yield_texts(data_path):
-    with open(data_path) as f:
-        for line in f:
-            item = json.loads(line)
-            yield item["text"]
-
-def yield_tags(data_path):
-    with open(data_path) as f:
-        for line in f:
-            item = json.loads(line)
-            yield item["tags"]
-
-def load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=False, data_cache=None, random_seed=42, 
-                 shuffle=True, shuffle_buffer=1000, load_buffer=1000):
-    def transform_data(texts, tags):
-        text_encoded = tokenizer.transform(texts)
-        tags_encoded = label_binarizer.transform(tags)
-
-        if sparse_labels:
-            tags_encoded = tags_encoded.todense() # returns matrix
-            tags_encoded = np.asarray(tags_encoded)
-        
-        return text_encoded, tags_encoded
-
-    def data_gen():
-        texts = []
-        tags = []
-        for text, tags_ in zip(yield_texts(data_path), yield_tags(data_path)):
-            texts.append(text)
-            tags.append(tags_)
-
-            if len(texts) >= load_buffer: 
-                text_encoded, tags_encoded = transform_data(texts, tags)
-                for i in range(len(texts)):
-                    yield text_encoded[i], tags_encoded[i]
-
-                texts = []
-                tags = []
-
-        if texts:
-            text_encoded, tags_encoded = transform_data(texts, tags)   
-            for i in range(len(texts)):
-                yield text_encoded[i], tags_encoded[i]
-
-    data = tf.data.Dataset.from_generator(data_gen, output_types=(tf.int32, tf.int32))
-
-    if shuffle:
-        data = data.shuffle(shuffle_buffer, seed=random_seed)
-    if data_cache:
-        data = data.cache(data_cache)
-    return data
-
-def load_train_test_dataset(data_path, tokenizer, label_binarizer, test_data_path=None, test_size=0.1, sparse_labels=False, data_cache=None, random_seed=42, shuffle=True, shuffle_buffer=1000):
-    # don't shuffle before splitting so only shuffle train_data
-    data = load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=sparse_labels,
-                        shuffle_buffer=shuffle_buffer, shuffle=False, data_cache=data_cache, 
-                        random_seed=random_seed)
-
-    if test_data_path:
-        test_data = load_dataset(data_path, tokenizer, label_binarizer, sparse_labels=sparse_labels,
-                                 shuffle_buffer=shuffle_buffer, shuffle=False, random_seed=random_seed) # cache will load train data if it has the same name
-        train_data = data
-    else:
-        print("Splitting train and test. This might take a while.")
-        steps = 0
-        for _ in data:
-            steps += 1
-
-        train_steps = int((1-test_size) * steps)
-
-        if shuffle:
-            # train / test shuffle should remain the same across epochs
-            data = data.shuffle(shuffle_buffer, seed=random_seed, reshuffle_each_iteration=False)
-        train_data = data.take(train_steps)
-        test_data = data.skip(train_steps)
-        print(f"Splitted. Train data size {train_steps}. Test data size {steps-train_steps}")
-
-    if shuffle:
-        train_data = train_data.shuffle(shuffle_buffer, seed=random_seed)
-
-    return train_data, test_data

--- a/grants_tagger/utils.py
+++ b/grants_tagger/utils.py
@@ -35,12 +35,14 @@ def load_data(data_path, label_binarizer=None, X_format="List"):
     return texts, tags, meta
  
 def yield_texts(data_path):
+    """Yields texts from JSONL with text field"""
     with open(data_path) as f:
         for line in f:
             item = json.loads(line)
             yield item["text"]
 
 def yield_tags(data_path, label_binarizer=None):
+    """Yields tags from JSONL with tags field. Transforms if label binarizer provided."""
     with open(data_path) as f:
         for line in f:
             item = json.loads(line)
@@ -54,7 +56,13 @@ def yield_tags(data_path, label_binarizer=None):
 def load_train_test_data(
         train_data_path, label_binarizer, test_data_path=None,
         test_size=None, data_format="list"):
-
+    """
+    train_data_path: path. path to JSONL data that contains text and tags fields
+    label_binarizer: MultiLabelBinarizer. multilabel binarizer instance used to transform tags
+    test_data_path: path, default None. path to test JSONL data similar to train_data
+    test_size: float, default None. if test_data_path not provided, dictates portion to be used as test
+    data_format: str, default list. controls data are returned as lists or generators for memory efficiency
+    """
     if data_format == "list":
         if test_data_path:
             X_train, Y_train, _ = load_data(train_data_path, label_binarizer)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scikit-multilearn
 arff
 python-dateutil<2.8.1,>=2.1
--e git+git://github.com/wellcometrust/WellcomeML.git@14668e8650516363453a85bc2a5546cfe8811951#egg=wellcomeml[deep-learning]
+-e git+git://github.com/wellcometrust/WellcomeML.git@0e6182af674f88e8cd4936e3204079a0be607ebd#egg=wellcomeml[deep-learning]

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,12 @@ setup(
         'scikit-learn==0.23.2',
         'nltk',
         'matplotlib',
-        'wellcomeml[deep-learning]==2021.2.1',
+        'wellcomeml[deep-learning]==1.0.2',
         'docutils==0.15',
         'scipy==1.4.1',
         'wasabi',
-        'typer'
+        'typer',
+        'scispacy'
     ],
     tests_require=[
         'pytest',

--- a/tests/test_evaluate_mesh_on_grants.py
+++ b/tests/test_evaluate_mesh_on_grants.py
@@ -2,13 +2,10 @@ import tempfile
 import os.path
 import pickle
 
-from sklearn.pipeline import Pipeline
-from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.preprocessing import MultiLabelBinarizer
-from sklearn.multiclass import OneVsRestClassifier
-from sklearn.svm import SVC
 import pandas as pd
 
+from grants_tagger.models import MeshCNN
 from grants_tagger.evaluate_mesh_on_grants import evaluate_mesh_on_grants
 
 
@@ -37,17 +34,14 @@ def test_evaluate_mesh_on_grants():
         with open(label_binarizer_path, "wb") as f:
             f.write(pickle.dumps(label_binarizer))
 
-        model = Pipeline([
-            ("tfidf", TfidfVectorizer()),
-            ("svm", OneVsRestClassifier(SVC(probability=True)))
-        ])
         X = texts
         Y = label_binarizer.transform(tags)
+
+        model = MeshCNN()
         model.fit(X, Y)
-        with open(model_path, "wb") as f:
-            f.write(pickle.dumps(model))
+        model.save(model_path)
 
         data = pd.DataFrame.from_records(VAL_DATA)
         data.to_excel(data_path, engine="openpyxl")
 
-        evaluate_mesh_on_grants(data_path, model_path, label_binarizer_path)
+        evaluate_mesh_on_grants("mesh-cnn", data_path, model_path, label_binarizer_path)

--- a/tests/test_evaluate_model.py
+++ b/tests/test_evaluate_model.py
@@ -24,7 +24,7 @@ Y = [
     ["24"]
 ]
 
-
+# TODO: Use fixtures 
 def create_test_data(data_path):
     with open(data_path, "w") as f:
         for x, y in zip(X, Y):
@@ -48,7 +48,7 @@ def test_evaluate_model():
             Y_test = [["1"], ["2"]]
             mock_predict.return_value = label_binarizer.transform(Y_test)
 
-            evaluate_model("model_path", data_path, label_binarizer_path, 0.5)
+            evaluate_model("mesh-cnn", "model_path", data_path, label_binarizer_path, 0.5)
             mock_predict.assert_called()
 
 
@@ -68,5 +68,5 @@ def test_evaluate_model_multiple_thresholds():
             Y_test = [["1"], ["2"]]
             mock_predict.return_value = label_binarizer.transform(Y_test)
 
-            evaluate_model("model_path", data_path, label_binarizer_path, [0,1,0.5,0.9])
+            evaluate_model("mesh-cnn", "model_path", data_path, label_binarizer_path, [0,1,0.5,0.9])
             mock_predict.assert_called()

--- a/tests/test_evaluate_model.py
+++ b/tests/test_evaluate_model.py
@@ -2,9 +2,11 @@ from unittest.mock import patch
 import tempfile
 import pickle
 import json
+import os
 
 from sklearn.preprocessing import MultiLabelBinarizer
 import numpy as np
+import pytest
 
 from grants_tagger.evaluate_model import evaluate_model, predict
 
@@ -24,50 +26,42 @@ Y = [
     ["24"]
 ]
 
-# TODO: Use fixtures 
-def create_test_data(data_path):
+def binarize_Y(Y, label_binarizer_path):
+    with open(label_binarizer_path, "rb") as f:
+        label_binarizer = pickle.loads(f.read())
+    return label_binarizer.transform(Y)
+
+@pytest.fixture
+def label_binarizer_path(tmp_path):
+    label_binarizer_path = os.path.join(tmp_path, "label_binarizer.pkl")
+
+    label_binarizer = MultiLabelBinarizer()
+    label_binarizer.fit(Y)
+    with open(label_binarizer_path, "wb") as f:
+        f.write(pickle.dumps(label_binarizer))
+    return label_binarizer_path
+
+@pytest.fixture
+def data_path(tmp_path):
+    data_path = os.path.join(tmp_path, "data.jsonl")
     with open(data_path, "w") as f:
         for x, y in zip(X, Y):
             item = json.dumps({"text": x, "tags": y, "meta": ""})
             f.write(item+"\n")
+    return data_path
 
-# TODO: patch predict
+def test_evaluate_model(data_path, label_binarizer_path):
+    with patch('grants_tagger.evaluate_model.predict') as mock_predict:
+        Y_test = [["1"], ["2"]]
+        mock_predict.return_value = binarize_Y(Y_test, label_binarizer_path)
 
-def test_evaluate_model():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
-        data_path = f"{tmp_dir}/data.jsonl"
+        evaluate_model("mesh-cnn", "model_path", data_path, label_binarizer_path, 0.5)
+        mock_predict.assert_called()
 
-        label_binarizer = MultiLabelBinarizer()
-        label_binarizer.fit(Y)
-        with open(label_binarizer_path, "wb") as f:
-            f.write(pickle.dumps(label_binarizer))
+def test_evaluate_model_multiple_thresholds(data_path, label_binarizer_path):
+    with patch('grants_tagger.evaluate_model.predict') as mock_predict:
+        Y_test = [["1"], ["2"]]
+        mock_predict.return_value = binarize_Y(Y_test, label_binarizer_path)
 
-        create_test_data(data_path)
-
-        with patch('grants_tagger.evaluate_model.predict') as mock_predict:
-            Y_test = [["1"], ["2"]]
-            mock_predict.return_value = label_binarizer.transform(Y_test)
-
-            evaluate_model("mesh-cnn", "model_path", data_path, label_binarizer_path, 0.5)
-            mock_predict.assert_called()
-
-
-def test_evaluate_model_multiple_thresholds():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
-        data_path = f"{tmp_dir}/data.jsonl"
-
-        label_binarizer = MultiLabelBinarizer()
-        label_binarizer.fit(Y)
-        with open(label_binarizer_path, "wb") as f:
-            f.write(pickle.dumps(label_binarizer))
-
-        create_test_data(data_path)
-
-        with patch('grants_tagger.evaluate_model.predict') as mock_predict:
-            Y_test = [["1"], ["2"]]
-            mock_predict.return_value = label_binarizer.transform(Y_test)
-
-            evaluate_model("mesh-cnn", "model_path", data_path, label_binarizer_path, [0,1,0.5,0.9])
-            mock_predict.assert_called()
+        evaluate_model("mesh-cnn", "model_path", data_path, label_binarizer_path, [0,1,0.5,0.9])
+        mock_predict.assert_called()

--- a/tests/test_evaluate_model.py
+++ b/tests/test_evaluate_model.py
@@ -31,6 +31,7 @@ def create_test_data(data_path):
             item = json.dumps({"text": x, "tags": y, "meta": ""})
             f.write(item+"\n")
 
+# TODO: patch predict
 
 def test_evaluate_model():
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,240 @@
+from skmultilearn.problem_transform import ClassifierChain, BinaryRelevance, LabelPowerset
+from sklearn.feature_extraction.text import HashingVectorizer, TfidfVectorizer
+from sklearn.ensemble import GradientBoostingClassifier, AdaBoostClassifier
+from sklearn.linear_model import SGDClassifier
+from sklearn.svm import SVC
+from sklearn.multiclass import OneVsRestClassifier
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder
+
+from wellcomeml.ml import BertVectorizer, BertClassifier, BiLSTMClassifier, CNNClassifier, KerasVectorizer, Doc2VecVectorizer, Sent2VecVectorizer, SpacyClassifier
+
+from grants_tagger.models import create_model, ApproachNotImplemented
+
+
+def test_create_hashing_vectorizer_svm():
+    model = create_model('hashing_vectorizer-svm')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    clf = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, HashingVectorizer)
+    assert isinstance(ovr, OneVsRestClassifier)
+    assert isinstance(clf, SGDClassifier)
+
+
+def test_create_hashing_vectorizer_nb():
+    model = create_model('hashing_vectorizer-nb')
+    vec = model.steps[0][1]
+    clf = model.steps[1][1]
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, HashingVectorizer)
+    assert isinstance(clf, OneVsRestClassifier)
+
+
+def test_create_tfidf_svm():
+    model = create_model('tfidf-svm')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    clf = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, TfidfVectorizer)
+    assert isinstance(ovr, OneVsRestClassifier)
+    assert isinstance(clf, SVC)
+
+
+def test_create_bert_svm():
+    model = create_model('bert-svm')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    clf = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, BertVectorizer)
+    assert isinstance(ovr, OneVsRestClassifier)
+    assert isinstance(clf, SVC)
+    assert vec.pretrained == 'bert'
+
+
+def test_create_scibert_svm():
+    model = create_model('scibert-svm')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    clf = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, BertVectorizer)
+    assert isinstance(ovr, OneVsRestClassifier)
+    assert isinstance(clf, SVC)
+    assert vec.pretrained == 'scibert'
+
+
+def test_create_bert():
+    model = create_model('bert')
+    assert isinstance(model, BertClassifier)
+    assert model.pretrained == 'bert-base-uncased'
+
+
+def test_create_scibert():
+    model = create_model('scibert')
+    assert isinstance(model, BertClassifier)
+    assert model.pretrained == 'scibert'
+
+
+def test_create_classifierchain_tfidf_svm():
+    model = create_model('classifierchain-tfidf-svm')
+    vec = model.steps[0][1]
+    cc = model.steps[1][1]
+    clf = cc.get_params()['classifier']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, TfidfVectorizer)
+    assert isinstance(cc, ClassifierChain)
+    assert isinstance(clf, SVC)
+
+
+def test_create_labelpowerset_tfidf_svm():
+    model = create_model('labelpowerset-tfidf-svm')
+    vec = model.steps[0][1]
+    lp = model.steps[1][1]
+    clf = lp.get_params()['classifier']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, TfidfVectorizer)
+    assert isinstance(lp, LabelPowerset)
+    assert isinstance(clf, SVC)
+
+
+def test_create_binaryrelevance_tfidf_svm():
+    model = create_model('binaryrelevance-tfidf-svm')
+    vec = model.steps[0][1]
+    br = model.steps[1][1]
+    clf = br.get_params()['classifier']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, TfidfVectorizer)
+    assert isinstance(br, BinaryRelevance)
+    assert isinstance(clf, SVC)
+
+
+def test_create_binaryrelevance_tfidf_knn():
+    model = create_model('binaryrelevance-tfidf-knn')
+    vec = model.steps[0][1]
+    br = model.steps[1][1]
+#    clf = br.get_params()['classifier']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, TfidfVectorizer)
+    assert isinstance(br, BinaryRelevance)
+#    assert isinstance(clf, KNeighborsClassifier)
+
+
+def test_create_bilstm():
+    model = create_model('bilstm')
+    vec = model.steps[0][1]
+    clf = model.steps[1][1]
+    assert isinstance(vec, KerasVectorizer)
+    assert isinstance(clf, BiLSTMClassifier)
+
+
+def test_create_cnn():
+    model = create_model('cnn')
+    vec = model.steps[0][1]
+    clf = model.steps[1][1]
+    assert isinstance(vec, KerasVectorizer)
+    assert isinstance(clf, CNNClassifier)
+
+
+def test_create_doc2vec_sgd():
+    model = create_model('doc2vec-sgd')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    clf = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, Doc2VecVectorizer)
+    assert isinstance(ovr, OneVsRestClassifier)
+    assert isinstance(clf, SGDClassifier)
+
+
+def test_create_sent2vec_sgd():
+    model = create_model('sent2vec-sgd')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    clf = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, Sent2VecVectorizer)
+    assert isinstance(ovr, OneVsRestClassifier)
+    assert isinstance(clf, SGDClassifier)
+
+
+def test_create_tfidf_adaboost():
+    model = create_model('tfidf-adaboost')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    clf = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, TfidfVectorizer)
+    assert isinstance(ovr, OneVsRestClassifier)
+    assert isinstance(clf, AdaBoostClassifier)
+
+
+def test_create_tfidf_gboost():
+    model = create_model('tfidf-gboost')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    clf = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(vec, TfidfVectorizer)
+    assert isinstance(ovr, OneVsRestClassifier)
+    assert isinstance(clf, GradientBoostingClassifier)
+
+
+def test_create_spacy_textclassifier():
+    model = create_model("spacy-textclassifier")
+    assert isinstance(model, SpacyClassifier)
+
+
+def test_create_doc2vec_tfidf_sgd():
+    model = create_model('doc2vec-tfidf-sgd')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    doc2vec = vec.transformer_list[0][1].steps[0][1]
+    tfidf = vec.transformer_list[1][1].steps[0][1]
+    sgd = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(doc2vec, Doc2VecVectorizer)
+    assert isinstance(tfidf, TfidfVectorizer)
+    assert isinstance(sgd, SGDClassifier)
+
+
+def test_create_sent2vec_tfidf_sgd():
+    model = create_model('sent2vec-tfidf-sgd')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    sent2vec = vec.transformer_list[0][1].steps[0][1]
+    tfidf = vec.transformer_list[1][1].steps[0][1]
+    sgd = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(sent2vec, Sent2VecVectorizer)
+    assert isinstance(tfidf, TfidfVectorizer)
+    assert isinstance(sgd, SGDClassifier)
+
+
+def test_create_tfidf_onehot_team_svm():
+    model = create_model('tfidf+onehot_team-svm')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    tfidf = vec.transformer_list[0][1].steps[1][1]
+    onehot = vec.transformer_list[1][1].steps[1][1]
+    sgd = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(onehot, OneHotEncoder)
+    assert isinstance(tfidf, TfidfVectorizer)
+    assert isinstance(sgd, SVC)
+
+
+def test_create_tfidf_onehot_scheme_svm():
+    model = create_model('tfidf+onehot_team-svm')
+    vec = model.steps[0][1]
+    ovr = model.steps[1][1]
+    tfidf = vec.transformer_list[0][1].steps[1][1]
+    onehot = vec.transformer_list[1][1].steps[1][1]
+    sgd = ovr.get_params()['estimator']
+    assert isinstance(model, Pipeline)
+    assert isinstance(onehot, OneHotEncoder)
+    assert isinstance(tfidf, TfidfVectorizer)
+    assert isinstance(sgd, SVC)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,6 +12,8 @@ from wellcomeml.ml import BertVectorizer, BertClassifier, BiLSTMClassifier, CNNC
 from grants_tagger.models import create_model, ApproachNotImplemented
 
 
+# TODO: Test new models
+
 def test_create_hashing_vectorizer_svm():
     model = create_model('hashing_vectorizer-svm')
     vec = model.steps[0][1]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -67,9 +67,9 @@ def test_mesh_tfidf_svm(tmp_path):
 
     model_path = os.path.join(tmp_path, "model")
     params = {
-        "vec__stop_words": None, 
-        "vec__min_df": 1,
-        "clf__estimator__loss": "log",
+        "tfidf__stop_words": None, 
+        "tfidf__min_df": 1,
+        "svm__estimator__loss": "log",
         "model_path": model_path,
         "y_batch_size": 64}
     model.set_params(**params)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -4,15 +4,18 @@ import shutil
 import pickle
 import os
 
+# TODO: Remove when ScienceEnsemble implements fit
+from sklearn.pipeline import Pipeline
 from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.preprocessing import MultiLabelBinarizer
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.linear_model import SGDClassifier
-from sklearn.pipeline import Pipeline
-from wellcomeml.ml import BertClassifier, CNNClassifier, KerasVectorizer
+from wellcomeml.ml import BertClassifier
+
+from sklearn.preprocessing import MultiLabelBinarizer
 import numpy as np
 
-from grants_tagger.predict import predict_tfidf_svm, predict_tags, predict
+from grants_tagger.models import MeshCNN, MeshTfidfSVM
+from grants_tagger.predict import predict_tags, predict
 
 X = [
     "all",
@@ -39,57 +42,39 @@ Y_mesh = [
 ]
 
 
-def train_test_tfidf_svm_model(model_path, label_binarizer_path):
-    tfidf = TfidfVectorizer()
-    tfidf.fit(X)
-    with open(f"{model_path}/tfidf.pkl", "wb") as f:
-        f.write(pickle.dumps(tfidf))
-
-    X_vec = tfidf.transform(X)
-
-    label_binarizer = MultiLabelBinarizer()
-    label_binarizer.fit(Y_mesh)
-    with open(f"{label_binarizer_path}", "wb") as f:
-        f.write(pickle.dumps(label_binarizer))
-        f.seek(0)
-
-    Y_vec = label_binarizer.transform(Y_mesh)
-
-    for tag_i in range(0, Y_vec.shape[1], 512):
-        model = OneVsRestClassifier(SGDClassifier(loss='log'))
-        model.fit(X_vec, Y_vec[:, tag_i:tag_i+512])
-        with open(f"{model_path}/{tag_i}.pkl", "wb") as f:
-            f.write(pickle.dumps(model))
-
-
-def train_test_cnn_model(model_path, label_binarizer_path):
-    vectorizer = KerasVectorizer()
-    vectorizer.fit(X)
-    with open(f"{model_path}/vectorizer.pkl", "wb") as f:
-        f.write(pickle.dumps(vectorizer))
-
-    X_vec = vectorizer.transform(X)
-
-    label_binarizer = MultiLabelBinarizer()
-    label_binarizer.fit(Y_mesh)
-    with open(f"{label_binarizer_path}", "wb") as f:
-        f.write(pickle.dumps(label_binarizer))
-        f.seek(0)
-
-    Y_vec = label_binarizer.transform(Y_mesh)
-
-    model = CNNClassifier(multilabel=True)
-    model.fit(X_vec, Y_vec)
-    model.save(model_path)
-
-
-def train_test_ensemble_model(scibert_path, tfidf_svm_path, label_binarizer_path):
+def train_label_binarizer(Y, label_binarizer_path):
     label_binarizer = MultiLabelBinarizer()
     label_binarizer.fit(Y)
     with open(f"{label_binarizer_path}", "wb") as f:
         f.write(pickle.dumps(label_binarizer))
         f.seek(0)
+    return label_binarizer
 
+def train_test_tfidf_svm_model(model_path, label_binarizer_path):
+    label_binarizer = train_label_binarizer(Y_mesh, label_binarizer_path)
+    Y_vec = label_binarizer.transform(Y_mesh)
+
+    model = MeshTfidfSVM(model_path=model_path)
+    model.set_params(
+        vec__min_df=1,
+        vec__stop_words=None,
+        clf__estimator__loss="log"
+    )
+    model.fit(X, Y_vec)
+    model.save(model_path)
+
+
+def train_test_cnn_model(model_path, label_binarizer_path):
+    label_binarizer = train_label_binarizer(Y_mesh, label_binarizer_path)
+    Y_vec = label_binarizer.transform(Y_mesh)
+
+    model = MeshCNN()
+    model.fit(X, Y_vec)
+    model.save(model_path)
+
+
+def train_test_ensemble_model(scibert_path, tfidf_svm_path, label_binarizer_path):
+    label_binarizer = train_label_binarizer(Y, label_binarizer_path)
     Y_vec = label_binarizer.transform(Y)
 
     tfidf_svm = Pipeline([
@@ -101,23 +86,14 @@ def train_test_ensemble_model(scibert_path, tfidf_svm_path, label_binarizer_path
     with open(tfidf_svm_path, "wb") as f:
         f.write(pickle.dumps(tfidf_svm))
 
-    scibert = BertClassifier()
+    scibert = BertClassifier(
+            epochs=1,
+            pretrained="scibert")
     scibert.fit(X, Y_vec)
     scibert.save(scibert_path)
 
 
-def test_predict_mesh_tfidf_svm():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        model_path = f"{tmp_dir}/disease_mesh_tfidf_model/"
-        os.mkdir(model_path)
-        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
-        train_test_tfidf_svm_model(model_path, label_binarizer_path)
-
-        tags = predict_tags(X, model_path, label_binarizer_path)
-        assert len(tags) == 5
-
-
-def test_predict_mesh_tfidf_svm_threshold():
+def test_predict_threshold():
     with tempfile.TemporaryDirectory() as tmp_dir:
         model_path = f"{tmp_dir}/disease_mesh_tfidf_model/"
         os.mkdir(model_path)
@@ -126,14 +102,16 @@ def test_predict_mesh_tfidf_svm_threshold():
 
         nb_examples = 5
         nb_labels = 5000
-        Y = predict_tfidf_svm(X, model_path, nb_labels, threshold=0, return_probabilities=False)
+        Y = predict(X, model_path, approach="mesh-tfidf-svm",
+                threshold=0, return_probabilities=False)
         assert Y.sum() == nb_labels * nb_examples # all 1
 
-        Y = predict_tfidf_svm(X, model_path, nb_labels, threshold=1, return_probabilities=False)
+        Y = predict(X, model_path, approach="mesh-tfidf-svm",
+                threshold=1, return_probabilities=False)
         assert Y.sum() == 0 # all 0
 
 
-def test_predict_tags_ensemble():
+def test_predict_tags_science_ensemble():
     with tempfile.TemporaryDirectory() as tmp_dir:
         scibert_path = f"{tmp_dir}/scibert/"
         os.mkdir(scibert_path)
@@ -141,33 +119,33 @@ def test_predict_tags_ensemble():
         label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
         train_test_ensemble_model(scibert_path, tfidf_svm_path, label_binarizer_path)
 
-        tags = predict_tags(X, model_path=[scibert_path,tfidf_svm_path],
-                            label_binarizer_path=label_binarizer_path)
+        model_path = ",".join([scibert_path, tfidf_svm_path])
+        tags = predict_tags(
+                X, model_path=model_path,
+                label_binarizer_path=label_binarizer_path,
+                approach="science-ensemble")
         assert len(tags) == 5
 
 
-def test_predict_tags_mesh():
+def test_predict_tags_mesh_tfidf_svm():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        model_path = f"{tmp_dir}/disease_mesh_tfidf_model/"
+        os.mkdir(model_path)
+        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
+        train_test_tfidf_svm_model(model_path, label_binarizer_path)
+
+        tags = predict_tags(X, model_path, label_binarizer_path, 
+                approach="mesh-tfidf-svm")
+        assert len(tags) == 5
+
+
+def test_predict_tags_mesh_cnn():
     with tempfile.TemporaryDirectory() as tmp_dir:
         model_path = f"{tmp_dir}/disease_mesh_cnn_model/"
         os.mkdir(model_path)
         label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
         train_test_cnn_model(model_path, label_binarizer_path)
 
-        tags = predict_tags(X, model_path, label_binarizer_path)
+        tags = predict_tags(X, model_path, label_binarizer_path,
+                approach="mesh-cnn")
         assert len(tags) == 5
-
-def test_evaluate_model_predict_cnn():
-    with patch('grants_tagger.predict.predict_cnn') as mock_predict_cnn:
-        predict("X_test", "disease_mesh_cnn_model_path", "nb_labels", "threshold")
-        mock_predict_cnn.assert_called()
-
-def test_evaluate_model_predict_tfidf_svm():
-    with patch('grants_tagger.predict.predict_tfidf_svm') as mock_predict_tfidf_svm:
-        predict("X_test", "disease_mesh_tfidf_model_path", "nb_labels", "threshold")
-        mock_predict_tfidf_svm.assert_called()
-
-def test_evaluate_model_predict_ensemble():
-    with patch('grants_tagger.predict.predict_proba_ensemble_tfidf_svm_bert') as mock_predict_ensemble:
-        mock_predict_ensemble.return_value = np.random.randn(2, 24)
-        predict("X_test", ["tfidf","bert_model_paths"], "nb_labels", 0.5)
-        mock_predict_ensemble.assert_called()

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -2,19 +2,13 @@ from unittest.mock import patch
 import tempfile
 import shutil
 import pickle
+import json
 import os
 
-# TODO: Remove when ScienceEnsemble implements fit
-from sklearn.pipeline import Pipeline
-from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.multiclass import OneVsRestClassifier
-from sklearn.linear_model import SGDClassifier
-from wellcomeml.ml import BertClassifier
-
-from sklearn.preprocessing import MultiLabelBinarizer
 import numpy as np
+import pytest
 
-from grants_tagger.models import MeshCNN, MeshTfidfSVM
+from grants_tagger.train import create_label_binarizer, train_and_evaluate
 from grants_tagger.predict import predict_tags, predict
 
 X = [
@@ -30,7 +24,7 @@ Y = [
     ["1", "2"],
     ["2"],
     ["4"],
-    ["24"]
+    ["23"]
 ]
 
 Y_mesh = [
@@ -41,114 +35,159 @@ Y_mesh = [
     ["1000"]
 ]
 
+def create_data(X, Y, data_path):
+    with open(data_path, "w") as f:
+        for x, y in zip(X, Y):
+            f.write(json.dumps({"text": x, "tags": y, "meta": {}}))
+            f.write("\n")
 
-def train_label_binarizer(Y, label_binarizer_path):
-    label_binarizer = MultiLabelBinarizer()
-    label_binarizer.fit(Y)
-    with open(f"{label_binarizer_path}", "wb") as f:
-        f.write(pickle.dumps(label_binarizer))
-        f.seek(0)
-    return label_binarizer
+@pytest.fixture
+def science_ensemble_path(tmp_path):
+    data_path = os.path.join(tmp_path, "data.jsonl")
+    create_data(X, Y, data_path)
 
-def train_test_tfidf_svm_model(model_path, label_binarizer_path):
-    label_binarizer = train_label_binarizer(Y_mesh, label_binarizer_path)
-    Y_vec = label_binarizer.transform(Y_mesh)
+    label_binarizer_path = os.path.join(tmp_path, "label_binarizer.pkl")
+    label_binarizer = create_label_binarizer(data_path, label_binarizer_path)
 
-    model = MeshTfidfSVM(model_path=model_path)
-    model.set_params(
-        vec__min_df=1,
-        vec__stop_words=None,
-        clf__estimator__loss="log"
-    )
-    model.fit(X, Y_vec)
-    model.save(model_path)
+    # TODO: Replace approach with science-ensemble when fit implemented
+    tfidf_svm_path = os.path.join(tmp_path, "tfidf_svm.pkl")
+    parameters = {
+        'tfidf__min_df': 1,
+        'tfidf__stop_words': None
+    }
+    train_and_evaluate(data_path, label_binarizer_path,
+            approach="tfidf-svm", model_path=tfidf_svm_path,
+            parameters=str(parameters), verbose=False)
 
-
-def train_test_cnn_model(model_path, label_binarizer_path):
-    label_binarizer = train_label_binarizer(Y_mesh, label_binarizer_path)
-    Y_vec = label_binarizer.transform(Y_mesh)
-
-    model = MeshCNN()
-    model.fit(X, Y_vec)
-    model.save(model_path)
-
-
-def train_test_ensemble_model(scibert_path, tfidf_svm_path, label_binarizer_path):
-    label_binarizer = train_label_binarizer(Y, label_binarizer_path)
-    Y_vec = label_binarizer.transform(Y)
-
-    tfidf_svm = Pipeline([
-        ('tfidf', TfidfVectorizer()),
-        ('svm', OneVsRestClassifier(SGDClassifier(loss='log')))
-    ])
+    scibert_path = os.path.join(tmp_path, "scibert")
+    parameters = {"epochs": 1}
+    train_and_evaluate(data_path, label_binarizer_path,
+            approach="scibert", model_path=scibert_path,
+            parameters=str(parameters), verbose=False)
     
-    tfidf_svm.fit(X, Y_vec)
-    with open(tfidf_svm_path, "wb") as f:
-        f.write(pickle.dumps(tfidf_svm))
+    science_ensemble_path = f"{tfidf_svm_path},{scibert_path}"
+    return science_ensemble_path
 
-    scibert = BertClassifier(
-            epochs=1,
-            pretrained="scibert")
-    scibert.fit(X, Y_vec)
-    scibert.save(scibert_path)
+@pytest.fixture
+def mesh_tfidf_svm_path(tmp_path):
+    mesh_data_path = os.path.join(tmp_path, "mesh_data.jsonl")
+    create_data(X, Y_mesh, mesh_data_path)
+    
+    label_binarizer_path = os.path.join(tmp_path, "label_binarizer.pkl")
 
-# TODO: Remove when production models test for thresholds
-def test_predict_threshold():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        model_path = f"{tmp_dir}/disease_mesh_tfidf_model/"
-        os.mkdir(model_path)
-        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
-        train_test_tfidf_svm_model(model_path, label_binarizer_path)
+    model_path = os.path.join(tmp_path, "mesh_tfidf_svm")
+    parameters = {
+        'vec__min_df': 1,
+        'vec__stop_words': None,
+        'clf__estimator__loss': 'log',
+        'model_path': model_path
+    }
+    train_and_evaluate(mesh_data_path, label_binarizer_path,
+        approach="mesh-tfidf-svm", model_path=model_path,
+        parameters=str(parameters), sparse_labels=True,
+        verbose=False)
+    return model_path
 
-        nb_examples = 5
-        nb_labels = 5000
-        Y = predict(X, model_path, approach="mesh-tfidf-svm",
-                threshold=0, return_probabilities=False)
-        assert Y.sum() == nb_labels * nb_examples # all 1
+@pytest.fixture
+def mesh_cnn_path(tmp_path):
+    mesh_data_path = os.path.join(tmp_path, "mesh_data.jsonl")
+    create_data(X, Y_mesh, mesh_data_path)
+ 
+    label_binarizer_path = os.path.join(tmp_path, "label_binarizer.pkl")
+    model_path = os.path.join(tmp_path, "mesh_cnn")
+    train_and_evaluate(mesh_data_path, label_binarizer_path,
+        approach="mesh-cnn", model_path=model_path,
+        verbose=False)
+    return model_path
 
-        Y = predict(X, model_path, approach="mesh-tfidf-svm",
-                threshold=1, return_probabilities=False)
-        assert Y.sum() == 0 # all 0
+@pytest.fixture
+def label_binarizer_path(tmp_path):
+    data_path = os.path.join(tmp_path, "mesh_data.jsonl")
+    create_data(X, Y, data_path)
+    
+    label_binarizer_path = os.path.join(tmp_path, "label_binarizer.pkl")
+    create_label_binarizer(data_path, label_binarizer_path)
+    return label_binarizer_path
 
-
-# TODO: Add test for probabilities for each production model
-# TODO: ADd test for threshold for each production model
-
-def test_predict_tags_science_ensemble():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        scibert_path = f"{tmp_dir}/scibert/"
-        os.mkdir(scibert_path)
-        tfidf_svm_path = f"{tmp_dir}/tfidf_svm.pkl"
-        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
-        train_test_ensemble_model(scibert_path, tfidf_svm_path, label_binarizer_path)
-
-        model_path = ",".join([scibert_path, tfidf_svm_path])
-        tags = predict_tags(
-                X, model_path=model_path,
-                label_binarizer_path=label_binarizer_path,
-                approach="science-ensemble")
-        assert len(tags) == 5
-
-
-def test_predict_tags_mesh_tfidf_svm():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        model_path = f"{tmp_dir}/disease_mesh_tfidf_model/"
-        os.mkdir(model_path)
-        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
-        train_test_tfidf_svm_model(model_path, label_binarizer_path)
-
-        tags = predict_tags(X, model_path, label_binarizer_path, 
-                approach="mesh-tfidf-svm")
-        assert len(tags) == 5
+@pytest.fixture
+def mesh_label_binarizer_path(tmp_path):
+    mesh_data_path = os.path.join(tmp_path, "mesh_data.jsonl")
+    create_data(X, Y_mesh, mesh_data_path)
+    
+    mesh_label_binarizer_path = os.path.join(tmp_path, "mesh_label_binarizer.pkl")
+    create_label_binarizer(mesh_data_path, mesh_label_binarizer_path)
+    return mesh_label_binarizer_path
 
 
-def test_predict_tags_mesh_cnn():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        model_path = f"{tmp_dir}/disease_mesh_cnn_model/"
-        os.mkdir(model_path)
-        label_binarizer_path = f"{tmp_dir}/label_binarizer.pkl"
-        train_test_cnn_model(model_path, label_binarizer_path)
+def test_predict_tags_science_ensemble(science_ensemble_path, label_binarizer_path):
+    tags = predict_tags(
+        X, model_path=science_ensemble_path,
+        label_binarizer_path=label_binarizer_path,
+        approach="science-ensemble")
+    assert len(tags) == 5
+    tags = predict_tags(
+        X, model_path=science_ensemble_path,
+        label_binarizer_path=label_binarizer_path,
+        approach="science-ensemble", probabilities=True)
+    for tags_ in tags:
+        for tag, prob in tags_.items():
+            assert 0 <= prob <= 1.0
+    tags = predict_tags(
+        X, model_path=science_ensemble_path,
+        label_binarizer_path=label_binarizer_path,
+        approach="science-ensemble", threshold=0)
+    for tags_ in tags:
+        assert len(tags_) == 24
+    tags = predict_tags(
+        X, model_path=science_ensemble_path,
+        label_binarizer_path=label_binarizer_path,
+        approach="science-ensemble", threshold=1)
+    for tags_ in tags:
+        assert len(tags_) == 0
+    
 
-        tags = predict_tags(X, model_path, label_binarizer_path,
-                approach="mesh-cnn")
-        assert len(tags) == 5
+def test_predict_tags_mesh_tfidf_svm(mesh_tfidf_svm_path, mesh_label_binarizer_path):
+    tags = predict_tags(
+        X, mesh_tfidf_svm_path, mesh_label_binarizer_path, 
+        approach="mesh-tfidf-svm")
+    assert len(tags) == 5
+    tags = predict_tags(
+        X, mesh_tfidf_svm_path, mesh_label_binarizer_path, 
+        approach="mesh-tfidf-svm", probabilities=True)
+    for tags_ in tags:
+        for tag, prob in tags_.items():
+            assert 0 <= prob <= 1.0
+    tags = predict_tags(
+        X, mesh_tfidf_svm_path, mesh_label_binarizer_path, 
+        approach="mesh-tfidf-svm", threshold=0)
+    for tags_ in tags:
+        assert len(tags_) == 5000
+    tags = predict_tags(
+        X, mesh_tfidf_svm_path, mesh_label_binarizer_path, 
+        approach="mesh-tfidf-svm", threshold=1)
+    for tags_ in tags:
+        assert len(tags_) == 0
+
+
+def test_predict_tags_mesh_cnn(mesh_cnn_path, mesh_label_binarizer_path):
+    tags = predict_tags(
+        X, mesh_cnn_path, mesh_label_binarizer_path,
+        approach="mesh-cnn")
+    assert len(tags) == 5
+    tags = predict_tags(
+        X, mesh_cnn_path, mesh_label_binarizer_path,
+        approach="mesh-cnn", probabilities=True)
+    for tags_ in tags:
+        for tag, prob in tags_.items():
+            assert 0 <= prob <= 1.0
+    tags = predict_tags(
+        X, mesh_cnn_path, mesh_label_binarizer_path,
+        approach="mesh-cnn", threshold=0)
+    for tags_ in tags:
+        assert len(tags_) == 5000
+    tags = predict_tags(
+        X, mesh_cnn_path, mesh_label_binarizer_path,
+        approach="mesh-cnn", threshold=1)
+    for tags_ in tags:
+        assert len(tags_) == 0
+

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -92,7 +92,7 @@ def train_test_ensemble_model(scibert_path, tfidf_svm_path, label_binarizer_path
     scibert.fit(X, Y_vec)
     scibert.save(scibert_path)
 
-
+# TODO: Remove when production models test for thresholds
 def test_predict_threshold():
     with tempfile.TemporaryDirectory() as tmp_dir:
         model_path = f"{tmp_dir}/disease_mesh_tfidf_model/"
@@ -110,6 +110,9 @@ def test_predict_threshold():
                 threshold=1, return_probabilities=False)
         assert Y.sum() == 0 # all 0
 
+
+# TODO: Add test for probabilities for each production model
+# TODO: ADd test for threshold for each production model
 
 def test_predict_tags_science_ensemble():
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -77,9 +77,9 @@ def mesh_tfidf_svm_path(tmp_path):
 
     model_path = os.path.join(tmp_path, "mesh_tfidf_svm")
     parameters = {
-        'vec__min_df': 1,
-        'vec__stop_words': None,
-        'clf__estimator__loss': 'log',
+        'tfidf__min_df': 1,
+        'tfidf__stop_words': None,
+        'svm__estimator__loss': 'log',
         'model_path': model_path
     }
     train_and_evaluate(mesh_data_path, label_binarizer_path,

--- a/tests/test_tag_grants.py
+++ b/tests/test_tag_grants.py
@@ -53,6 +53,8 @@ def train_test_model(scibert_path, tfidf_svm_path, label_binarizer_path):
     scibert.fit(X, Y_vec)
     scibert.save(scibert_path)
 
+# TODO: Patch predict_tags
+
 def test_tag_grants():
     with tempfile.TemporaryDirectory() as tmp_dir:
         scibert_path = f"{tmp_dir}/scibert/"

--- a/tests/test_tag_grants.py
+++ b/tests/test_tag_grants.py
@@ -46,7 +46,10 @@ def train_test_model(scibert_path, tfidf_svm_path, label_binarizer_path):
     with open(tfidf_svm_path, "wb") as f:
         f.write(pickle.dumps(tfidf_svm))
 
-    scibert = BertClassifier()
+    scibert = BertClassifier(
+        epochs=1,
+        pretrained="scibert"
+    )
     scibert.fit(X, Y_vec)
     scibert.save(scibert_path)
 
@@ -79,7 +82,8 @@ def test_tag_grants():
                 grants_path,
                 tagged_grants_path,
                 model_path=tfidf_svm_path,
-                label_binarizer_path=label_binarizer_path
+                label_binarizer_path=label_binarizer_path,
+                approach="science-ensemble"
             )
         tagged_grants = []
         with open(tagged_grants_path) as f:

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -12,32 +12,23 @@ import pytest
 from grants_tagger.train import train_and_evaluate, create_label_binarizer
 
 
-# TODO: Use train and test_data_path fixtures
-@pytest.fixture()
-def data_path(tmp_path):
-    texts = ["one", "one two", "two"]
-    tags = [["one"], ["one","two"], ["two"]]
-    meta = [{}, {}, {}]
-
-    test_data_path = os.path.join(tmp_path, "data.jsonl")
-
-    with open(test_data_path, "w") as f:
-        for text, tags_, meta_ in zip(texts, tags, meta):
-            example = {"text": text, "tags": tags_, "meta": meta_}
-            f.write(json.dumps(example)+"\n")
-    return test_data_path
+@pytest.fixture
+def data_path(tmp_path, train_data_path, test_data_path):
+    data_path = os.path.join(tmp_path, "data.jsonl")
+    with open(data_path, "w") as data_f:
+        with open(train_data_path, "r") as train_f:
+            for line in train_f:
+                data_f.write(line)
+        with open(test_data_path, "r") as test_f:
+            for line in test_f:
+                data_f.write(line)
+    return data_path
 
 
-# TODO: Use data_path fixture and create_label_binarizer
-@pytest.fixture()
-def label_binarizer_path(tmp_path):
-    label_binarizer_path = os.path.join(tmp_path, "label_binarizer.pkl")
-    
-    label_binarizer = MultiLabelBinarizer()
-    label_binarizer.fit([["one", "two"]])
-    
-    with open(label_binarizer_path, "wb") as f:
-        f.write(pickle.dumps(label_binarizer))
+@pytest.fixture
+def label_binarizer_path(tmp_path, data_path):
+    label_binarizer_path = os.path.join(tmp_path, "label_binarizer.pkl") 
+    create_label_binarizer(data_path, label_binarizer_path)
     return label_binarizer_path
 
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -155,35 +155,3 @@ def test_train_and_evaluate_threshold(data_path, label_binarizer_path):
         threshold=0, parameters="{'tfidf__min_df': 1, 'tfidf__stop_words': None}")
     assert f1 == (2/3) # P: 0.5, R: 1.0, F: 0.66
 
-
-# TODO: Move to models
-def test_train_and_evaluate_y_batch_size():
-    approach = "mesh-tfidf-svm"
-
-    texts = ["one", "one two", "all"]
-    tags = [["1"], ["1", "2"], [str(i) for i in range(5000)]]
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
-        train_data_path = os.path.join(tmp_dir, "train_data.jsonl")
-        model_path = os.path.join(tmp_dir, "model")
-
-        with open(train_data_path, "w") as train_data_tmp:
-            for text, tags_ in zip(texts, tags):
-                train_data_tmp.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
-                train_data_tmp.write("\n")
-        
-        parameters = {
-            'vec__min_df': 1,
-            'vec__stop_words': None,
-            'y_batch_size': 512,
-            'model_path': model_path
-        }
-        train_and_evaluate(
-            train_data_path, label_binarizer_path, approach,
-            parameters=str(parameters),
-            model_path=model_path, sparse_labels=True)
-
-        model_artifacts = os.listdir(model_path)
-        assert len(model_artifacts) == math.ceil(5000 / 512) + 2 # (vectorizer, meta)
-

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -7,178 +7,153 @@ import os
 from sklearn.preprocessing import MultiLabelBinarizer
 from scipy.sparse import csr_matrix
 import numpy as np
+import pytest
 
 from grants_tagger.train import train_and_evaluate, create_label_binarizer
 
 
-# TODO: Use fixtures to reduce duplication
-
-def test_create_label_binarizer():
+# TODO: Use train and test_data_path fixtures
+@pytest.fixture()
+def data_path(tmp_path):
     texts = ["one", "one two", "two"]
     tags = [["one"], ["one","two"], ["two"]]
+    meta = [{}, {}, {}]
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
-        data_path = os.path.join(tmp_dir, "data.jsonl")
+    test_data_path = os.path.join(tmp_path, "data.jsonl")
 
-        with open(data_path, "w") as f:
-            for text, tags_ in zip(texts, tags):
-                example = {"text": text, "tags": tags_}
-                f.write(json.dumps(example)+"\n")
-
-        create_label_binarizer(data_path, label_binarizer_path)
-
-        with open(label_binarizer_path, "rb") as f:
-            label_binarizer = pickle.loads(f.read())
-
-        Y = label_binarizer.transform([["one"]])
-
-        assert "one" in label_binarizer.classes_
-        assert "two" in label_binarizer.classes_
-        assert len(label_binarizer.classes_) == 2
-        assert isinstance(Y, np.ndarray)
+    with open(test_data_path, "w") as f:
+        for text, tags_, meta_ in zip(texts, tags, meta):
+            example = {"text": text, "tags": tags_, "meta": meta_}
+            f.write(json.dumps(example)+"\n")
+    return test_data_path
 
 
-def test_create_label_binarizer_sparse():
-    texts = ["one", "one two", "two"]
-    tags = [["one"], ["one","two"], ["two"]]
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
-        data_path = os.path.join(tmp_dir, "data.jsonl")
-
-        with open(data_path, "w") as f:
-            for text, tags_ in zip(texts, tags):
-                example = {"text": text, "tags": tags_}
-                f.write(json.dumps(example)+"\n")
-
-        create_label_binarizer(data_path, label_binarizer_path, sparse=True)
-
-        with open(label_binarizer_path, "rb") as f:
-            label_binarizer = pickle.loads(f.read())
-
-        Y = label_binarizer.transform([["one"]])
-
-        assert "one" in label_binarizer.classes_
-        assert "two" in label_binarizer.classes_
-        assert len(label_binarizer.classes_) == 2
-        assert isinstance(Y, csr_matrix)
+# TODO: Use data_path fixture and create_label_binarizer
+@pytest.fixture()
+def label_binarizer_path(tmp_path):
+    label_binarizer_path = os.path.join(tmp_path, "label_binarizer.pkl")
+    
+    label_binarizer = MultiLabelBinarizer()
+    label_binarizer.fit([["one", "two"]])
+    
+    with open(label_binarizer_path, "wb") as f:
+        f.write(pickle.dumps(label_binarizer))
+    return label_binarizer_path
 
 
-def test_train_and_evaluate():
+@pytest.fixture
+def train_data_path(tmp_path):
+    texts = ["one", "one two"]
+    tags = [["one"], ["one","two"]]
+    meta = [{}, {}]
+    test_data_path = os.path.join(tmp_path, "train_data.jsonl")
+
+    with open(test_data_path, "w") as f:
+        for text, tags_, meta_ in zip(texts, tags, meta):
+            example = {"text": text, "tags": tags_, "meta": meta_}
+            f.write(json.dumps(example)+"\n")
+    return test_data_path
+
+
+@pytest.fixture
+def test_data_path(tmp_path):
+    texts = ["two"]
+    tags = [["two"]]
+    meta = [{}]
+
+    test_data_path = os.path.join(tmp_path, "test_data.jsonl")
+
+    with open(test_data_path, "w") as f:
+        for text, tags_, meta_ in zip(texts, tags, meta):
+            example = {"text": text, "tags": tags_, "meta": meta_}
+            f.write(json.dumps(example)+"\n")
+    return test_data_path
+
+
+def test_create_label_binarizer(tmp_path, data_path):
+    label_binarizer_path = os.path.join(tmp_path, "label_binarizer.pkl")
+    create_label_binarizer(data_path, label_binarizer_path)
+
+    with open(label_binarizer_path, "rb") as f:
+        label_binarizer = pickle.loads(f.read())
+
+    Y = label_binarizer.transform([["one"]])
+
+    assert "one" in label_binarizer.classes_
+    assert "two" in label_binarizer.classes_
+    assert len(label_binarizer.classes_) == 2
+    assert isinstance(Y, np.ndarray)
+
+
+def test_create_label_binarizer_sparse(tmp_path, data_path):
+    label_binarizer_path = os.path.join(tmp_path, "label_binarizer.pkl")
+
+    create_label_binarizer(data_path, label_binarizer_path, sparse=True)
+
+    with open(label_binarizer_path, "rb") as f:
+        label_binarizer = pickle.loads(f.read())
+
+    Y = label_binarizer.transform([["one"]])
+
+    assert "one" in label_binarizer.classes_
+    assert "two" in label_binarizer.classes_
+    assert len(label_binarizer.classes_) == 2
+    assert isinstance(Y, csr_matrix)
+
+
+def test_train_and_evaluate(data_path, label_binarizer_path):
     approach = "tfidf-svm"
 
-    texts = ["one", "one two", "two"]
-    tags = [["one"], ["one", "two"], ["two"]]
-    with tempfile.NamedTemporaryFile("r+") as train_data_tmp:
-        label_binarizer = MultiLabelBinarizer()
-        label_binarizer.fit(tags)
-        with tempfile.NamedTemporaryFile() as label_binarizer_tmp:
-            label_binarizer_tmp.write(pickle.dumps(label_binarizer))
-
-            for text, tags_ in zip(texts, tags):
-                train_data_tmp.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
-                train_data_tmp.write("\n")
-
-            train_data_tmp.seek(0)
-            label_binarizer_tmp.seek(0)
-
-            train_and_evaluate(train_data_tmp.name, label_binarizer_tmp.name, approach,
-                               parameters="{'tfidf__min_df': 1, 'tfidf__stop_words': None}")
+    train_and_evaluate(data_path, label_binarizer_path, approach,
+        parameters="{'tfidf__min_df': 1, 'tfidf__stop_words': None}")
 
 
-def test_train_pickle_save():
-    pass
+def test_train_pickle_save(tmp_path, data_path, label_binarizer_path):
+    approach = "tfidf-svm"
 
-def test_train_model_save():
+    model_path = os.path.join(tmp_path, "model.pkl")
+    train_and_evaluate(data_path, label_binarizer_path, approach=approach,
+        model_path=model_path, parameters="{'tfidf__min_df': 1, 'tfidf__stop_words': None}")
+    assert os.path.exists(model_path)
+
+
+def test_train_model_save(tmp_path, data_path, label_binarizer_path):
     approach = "mesh-cnn"
 
-    texts = ["one", "one two", "two"]
-    tags = [["one"], ["one","two"], ["two"]]
+    train_and_evaluate(data_path, label_binarizer_path,
+        approach, model_path=tmp_path)
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
-        train_data_path = os.path.join(tmp_dir, "train_data.jsonl")
-
-        label_binarizer = MultiLabelBinarizer()
-        label_binarizer.fit(tags)
-        with open(label_binarizer_path, "wb") as label_binarizer_tmp:
-            label_binarizer_tmp.write(pickle.dumps(label_binarizer))
-
-        with open(train_data_path, "w") as train_data_tmp:
-            for text, tags_ in zip(texts, tags):
-                train_data_tmp.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
-                train_data_tmp.write("\n")
-
-        train_and_evaluate(train_data_tmp.name, label_binarizer_tmp.name,
-                           approach, model_path=tmp_dir)
-
-        expected_vectorizer_path = os.path.join(tmp_dir, "vectorizer.pkl")
-        expected_model_variables_path = os.path.join(tmp_dir, "variables")
-        expected_model_assets_path = os.path.join(tmp_dir, "assets")
-        assert os.path.exists(expected_vectorizer_path)
-        assert os.path.exists(expected_model_variables_path)
-        assert os.path.exists(expected_model_assets_path)
+    expected_vectorizer_path = os.path.join(tmp_path, "vectorizer.pkl")
+    expected_model_variables_path = os.path.join(tmp_path, "variables")
+    expected_model_assets_path = os.path.join(tmp_path, "assets")
+    assert os.path.exists(expected_vectorizer_path)
+    assert os.path.exists(expected_model_variables_path)
+    assert os.path.exists(expected_model_assets_path)
 
 
-def test_train_and_evaluate_generator():
+def test_train_and_evaluate_generator(train_data_path, test_data_path, label_binarizer_path):
     approach = "mesh-cnn"
 
-    train_texts = ["one", "one two"]
-    train_tags = [["one"], ["one", "two"]]
-    
-    test_texts = ["two"]
-    test_tags = [["two"]]
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        train_data_path = os.path.join(tmp_dir, "train_data.jsonl")
-        test_data_path = os.path.join(tmp_dir, "test_data.jsonl")
-        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
-
-        with open(train_data_path, "w") as f:
-            for text, tags_ in zip(train_texts, train_tags):
-                f.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
-                f.write("\n")
-
-        with open(test_data_path, "w") as f:
-            for text, tags_ in zip(test_texts, test_tags):
-                f.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
-                f.write("\n")
-
-        train_and_evaluate(train_data_path, label_binarizer_path, approach,
-                           data_format="generator", sparse_labels=True, test_data_path=test_data_path)
+    train_and_evaluate(train_data_path, label_binarizer_path, approach,
+        data_format="generator", sparse_labels=True, test_data_path=test_data_path)
 
 
-def test_train_and_evaluate_generator_non_sparse_labels():
+def test_train_and_evaluate_generator_non_sparse_labels(train_data_path, test_data_path, label_binarizer_path):
     approach = "mesh-cnn"
 
-    train_texts = ["one", "one two"]
-    train_tags = [["one"], ["one", "two"]]
-    
-    test_texts = ["two"]
-    test_tags = [["two"]]
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        train_data_path = os.path.join(tmp_dir, "train_data.jsonl")
-        test_data_path = os.path.join(tmp_dir, "test_data.jsonl")
-        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
-
-        with open(train_data_path, "w") as f:
-            for text, tags_ in zip(train_texts, train_tags):
-                f.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
-                f.write("\n")
-
-        with open(test_data_path, "w") as f:
-            for text, tags_ in zip(test_texts, test_tags):
-                f.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
-                f.write("\n")
-        
-        train_and_evaluate(train_data_path, label_binarizer_path, approach,
-                           data_format="generator", test_data_path=test_data_path)
+    train_and_evaluate(train_data_path, label_binarizer_path, approach,
+        data_format="generator", test_data_path=test_data_path)
 
 
-def test_train_and_evaluate_threshold():
-    pass
+def test_train_and_evaluate_threshold(data_path, label_binarizer_path):
+    approach = "tfidf-svm"
+
+    f1 = train_and_evaluate(data_path, label_binarizer_path, approach=approach,
+        threshold=1, parameters="{'tfidf__min_df': 1, 'tfidf__stop_words': None}")
+    assert f1 == 0
+    f1 = train_and_evaluate(data_path, label_binarizer_path, approach=approach,
+        threshold=0, parameters="{'tfidf__min_df': 1, 'tfidf__stop_words': None}")
+    assert f1 == (2/3) # P: 0.5, R: 1.0, F: 0.66
 
 
 # TODO: Move to models

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,250 +1,18 @@
 import tempfile
 import pickle
 import json
+import math
 import os
 
-from skmultilearn.problem_transform import ClassifierChain, BinaryRelevance, LabelPowerset
-from sklearn.preprocessing import MultiLabelBinarizer, OneHotEncoder
-from sklearn.feature_extraction.text import HashingVectorizer, TfidfVectorizer
-from sklearn.ensemble import GradientBoostingClassifier, AdaBoostClassifier
-from sklearn.linear_model import SGDClassifier
-from sklearn.svm import SVC
-from sklearn.multiclass import OneVsRestClassifier
-from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import MultiLabelBinarizer
 from scipy.sparse import csr_matrix
 import numpy as np
 
-from wellcomeml.ml import BertVectorizer, BertClassifier, BiLSTMClassifier, CNNClassifier, KerasVectorizer, Doc2VecVectorizer, Sent2VecVectorizer, SpacyClassifier
-from grants_tagger.train import train_and_evaluate, ApproachNotImplemented, create_model, create_label_binarizer
+from grants_tagger.train import train_and_evaluate, create_label_binarizer
 
 
-def test_create_hashing_vectorizer_svm():
-    model = create_model('hashing_vectorizer-svm')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    clf = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, HashingVectorizer)
-    assert isinstance(ovr, OneVsRestClassifier)
-    assert isinstance(clf, SGDClassifier)
-
-
-def test_create_hashing_vectorizer_nb():
-    model = create_model('hashing_vectorizer-nb')
-    vec = model.steps[0][1]
-    clf = model.steps[1][1]
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, HashingVectorizer)
-    assert isinstance(clf, OneVsRestClassifier)
-
-
-def test_create_tfidf_svm():
-    model = create_model('tfidf-svm')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    clf = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, TfidfVectorizer)
-    assert isinstance(ovr, OneVsRestClassifier)
-    assert isinstance(clf, SVC)
-
-
-def test_create_bert_svm():
-    model = create_model('bert-svm')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    clf = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, BertVectorizer)
-    assert isinstance(ovr, OneVsRestClassifier)
-    assert isinstance(clf, SVC)
-    assert vec.pretrained == 'bert'
-
-
-def test_create_scibert_svm():
-    model = create_model('scibert-svm')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    clf = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, BertVectorizer)
-    assert isinstance(ovr, OneVsRestClassifier)
-    assert isinstance(clf, SVC)
-    assert vec.pretrained == 'scibert'
-
-
-def test_create_bert():
-    model = create_model('bert')
-    assert isinstance(model, BertClassifier)
-    assert model.pretrained == 'bert-base-uncased'
-
-
-def test_create_scibert():
-    model = create_model('scibert')
-    assert isinstance(model, BertClassifier)
-    assert model.pretrained == 'scibert'
-
-
-def test_create_classifierchain_tfidf_svm():
-    model = create_model('classifierchain-tfidf-svm')
-    vec = model.steps[0][1]
-    cc = model.steps[1][1]
-    clf = cc.get_params()['classifier']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, TfidfVectorizer)
-    assert isinstance(cc, ClassifierChain)
-    assert isinstance(clf, SVC)
-
-
-def test_create_labelpowerset_tfidf_svm():
-    model = create_model('labelpowerset-tfidf-svm')
-    vec = model.steps[0][1]
-    lp = model.steps[1][1]
-    clf = lp.get_params()['classifier']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, TfidfVectorizer)
-    assert isinstance(lp, LabelPowerset)
-    assert isinstance(clf, SVC)
-
-
-def test_create_binaryrelevance_tfidf_svm():
-    model = create_model('binaryrelevance-tfidf-svm')
-    vec = model.steps[0][1]
-    br = model.steps[1][1]
-    clf = br.get_params()['classifier']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, TfidfVectorizer)
-    assert isinstance(br, BinaryRelevance)
-    assert isinstance(clf, SVC)
-
-
-def test_create_binaryrelevance_tfidf_knn():
-    model = create_model('binaryrelevance-tfidf-knn')
-    vec = model.steps[0][1]
-    br = model.steps[1][1]
-#    clf = br.get_params()['classifier']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, TfidfVectorizer)
-    assert isinstance(br, BinaryRelevance)
-#    assert isinstance(clf, KNeighborsClassifier)
-
-
-def test_create_bilstm():
-    model = create_model('bilstm')
-    vec = model.steps[0][1]
-    clf = model.steps[1][1]
-    assert isinstance(vec, KerasVectorizer)
-    assert isinstance(clf, BiLSTMClassifier)
-
-
-def test_create_cnn():
-    model = create_model('cnn')
-    vec = model.steps[0][1]
-    clf = model.steps[1][1]
-    assert isinstance(vec, KerasVectorizer)
-    assert isinstance(clf, CNNClassifier)
-
-
-def test_create_doc2vec_sgd():
-    model = create_model('doc2vec-sgd')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    clf = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, Doc2VecVectorizer)
-    assert isinstance(ovr, OneVsRestClassifier)
-    assert isinstance(clf, SGDClassifier)
-
-
-def test_create_sent2vec_sgd():
-    model = create_model('sent2vec-sgd')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    clf = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, Sent2VecVectorizer)
-    assert isinstance(ovr, OneVsRestClassifier)
-    assert isinstance(clf, SGDClassifier)
-
-
-def test_create_tfidf_adaboost():
-    model = create_model('tfidf-adaboost')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    clf = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, TfidfVectorizer)
-    assert isinstance(ovr, OneVsRestClassifier)
-    assert isinstance(clf, AdaBoostClassifier)
-
-
-def test_create_tfidf_gboost():
-    model = create_model('tfidf-gboost')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    clf = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(vec, TfidfVectorizer)
-    assert isinstance(ovr, OneVsRestClassifier)
-    assert isinstance(clf, GradientBoostingClassifier)
-
-
-def test_create_spacy_textclassifier():
-    model = create_model("spacy-textclassifier")
-    assert isinstance(model, SpacyClassifier)
-
-
-def test_create_doc2vec_tfidf_sgd():
-    model = create_model('doc2vec-tfidf-sgd')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    doc2vec = vec.transformer_list[0][1].steps[0][1]
-    tfidf = vec.transformer_list[1][1].steps[0][1]
-    sgd = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(doc2vec, Doc2VecVectorizer)
-    assert isinstance(tfidf, TfidfVectorizer)
-    assert isinstance(sgd, SGDClassifier)
-
-
-def test_create_sent2vec_tfidf_sgd():
-    model = create_model('sent2vec-tfidf-sgd')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    sent2vec = vec.transformer_list[0][1].steps[0][1]
-    tfidf = vec.transformer_list[1][1].steps[0][1]
-    sgd = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(sent2vec, Sent2VecVectorizer)
-    assert isinstance(tfidf, TfidfVectorizer)
-    assert isinstance(sgd, SGDClassifier)
-
-
-def test_create_tfidf_onehot_team_svm():
-    model = create_model('tfidf+onehot_team-svm')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    tfidf = vec.transformer_list[0][1].steps[1][1]
-    onehot = vec.transformer_list[1][1].steps[1][1]
-    sgd = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(onehot, OneHotEncoder)
-    assert isinstance(tfidf, TfidfVectorizer)
-    assert isinstance(sgd, SVC)
-
-
-def test_create_tfidf_onehot_scheme_svm():
-    model = create_model('tfidf+onehot_team-svm')
-    vec = model.steps[0][1]
-    ovr = model.steps[1][1]
-    tfidf = vec.transformer_list[0][1].steps[1][1]
-    onehot = vec.transformer_list[1][1].steps[1][1]
-    sgd = ovr.get_params()['estimator']
-    assert isinstance(model, Pipeline)
-    assert isinstance(onehot, OneHotEncoder)
-    assert isinstance(tfidf, TfidfVectorizer)
-    assert isinstance(sgd, SVC)
-
+# TODO: Use fixtures to reduce duplication
+# TODO: Add test for ScienceEnsemble
 
 def test_train_and_evaluate():
     approach = "tfidf-svm"
@@ -269,7 +37,7 @@ def test_train_and_evaluate():
 
 
 def test_train_and_evaluate_y_batch_size():
-    approach = "tfidf-svm"
+    approach = "mesh-tfidf-svm"
 
     texts = ["one", "one two", "all"]
     tags = [["1"], ["1", "2"], [str(i) for i in range(5000)]]
@@ -283,15 +51,24 @@ def test_train_and_evaluate_y_batch_size():
             for text, tags_ in zip(texts, tags):
                 train_data_tmp.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
                 train_data_tmp.write("\n")
-
+        
+        parameters = {
+            'vec__min_df': 1,
+            'vec__stop_words': None,
+            'y_batch_size': 512,
+            'model_path': model_path
+        }
         train_and_evaluate(
             train_data_path, label_binarizer_path, approach,
-            parameters="{'tfidf__min_df': 1, 'tfidf__stop_words': None}",
-            y_batch_size=512, model_path=model_path, sparse_labels=True)
+            parameters=str(parameters),
+            model_path=model_path, sparse_labels=True)
+
+        model_artifacts = os.listdir(model_path)
+        assert len(model_artifacts) == math.ceil(5000 / 512) + 2 # (vectorizer, meta)
 
 
 def test_train_cnn_save():
-    approach = "cnn"
+    approach = "mesh-cnn"
 
     texts = ["one", "one two", "two"]
     tags = [["one"], ["one","two"], ["two"]]
@@ -373,39 +150,56 @@ def test_create_label_binarizer_sparse():
         assert isinstance(Y, csr_matrix)
 
 
-def test_train_and_evaluate_incremental_learning():
-    approach = "cnn"
+def test_train_and_evaluate_generator():
+    approach = "mesh-cnn"
 
-    texts = ["one", "one two", "two"]
-    tags = [["one"], ["one", "two"], ["two"]]
+    train_texts = ["one", "one two"]
+    train_tags = [["one"], ["one", "two"]]
+    
+    test_texts = ["two"]
+    test_tags = [["two"]]
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        train_data_path = os.path.join(tmp_dir, "data.jsonl")
+        train_data_path = os.path.join(tmp_dir, "train_data.jsonl")
+        test_data_path = os.path.join(tmp_dir, "test_data.jsonl")
         label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
 
         with open(train_data_path, "w") as f:
-            for text, tags_ in zip(texts, tags):
+            for text, tags_ in zip(train_texts, train_tags):
+                f.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
+                f.write("\n")
+
+        with open(test_data_path, "w") as f:
+            for text, tags_ in zip(test_texts, test_tags):
                 f.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
                 f.write("\n")
 
         train_and_evaluate(train_data_path, label_binarizer_path, approach,
-                           incremental_learning=True, sparse_labels=True)
+                           data_format="generator", sparse_labels=True, test_data_path=test_data_path)
 
+def test_train_and_evaluate_generator_non_sparse_labels():
+    approach = "mesh-cnn"
 
-def test_train_and_evaluate_incremental_learning_non_sparse_labels():
-    approach = "cnn"
-
-    texts = ["one", "one two", "two"]
-    tags = [["one"], ["one", "two"], ["two"]]
+    train_texts = ["one", "one two"]
+    train_tags = [["one"], ["one", "two"]]
+    
+    test_texts = ["two"]
+    test_tags = [["two"]]
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        train_data_path = os.path.join(tmp_dir, "data.jsonl")
+        train_data_path = os.path.join(tmp_dir, "train_data.jsonl")
+        test_data_path = os.path.join(tmp_dir, "test_data.jsonl")
         label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
 
         with open(train_data_path, "w") as f:
-            for text, tags_ in zip(texts, tags):
+            for text, tags_ in zip(train_texts, train_tags):
                 f.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
                 f.write("\n")
 
+        with open(test_data_path, "w") as f:
+            for text, tags_ in zip(test_texts, test_tags):
+                f.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
+                f.write("\n")
+        
         train_and_evaluate(train_data_path, label_binarizer_path, approach,
-                           incremental_learning=True)
+                           data_format="generator", test_data_path=test_data_path)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -12,91 +12,6 @@ from grants_tagger.train import train_and_evaluate, create_label_binarizer
 
 
 # TODO: Use fixtures to reduce duplication
-# TODO: Add test for ScienceEnsemble
-
-def test_train_and_evaluate():
-    approach = "tfidf-svm"
-
-    texts = ["one", "one two", "two"]
-    tags = [["one"], ["one", "two"], ["two"]]
-    with tempfile.NamedTemporaryFile("r+") as train_data_tmp:
-        label_binarizer = MultiLabelBinarizer()
-        label_binarizer.fit(tags)
-        with tempfile.NamedTemporaryFile() as label_binarizer_tmp:
-            label_binarizer_tmp.write(pickle.dumps(label_binarizer))
-
-            for text, tags_ in zip(texts, tags):
-                train_data_tmp.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
-                train_data_tmp.write("\n")
-
-            train_data_tmp.seek(0)
-            label_binarizer_tmp.seek(0)
-
-            train_and_evaluate(train_data_tmp.name, label_binarizer_tmp.name, approach,
-                               parameters="{'tfidf__min_df': 1, 'tfidf__stop_words': None}")
-
-
-def test_train_and_evaluate_y_batch_size():
-    approach = "mesh-tfidf-svm"
-
-    texts = ["one", "one two", "all"]
-    tags = [["1"], ["1", "2"], [str(i) for i in range(5000)]]
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
-        train_data_path = os.path.join(tmp_dir, "train_data.jsonl")
-        model_path = os.path.join(tmp_dir, "model")
-
-        with open(train_data_path, "w") as train_data_tmp:
-            for text, tags_ in zip(texts, tags):
-                train_data_tmp.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
-                train_data_tmp.write("\n")
-        
-        parameters = {
-            'vec__min_df': 1,
-            'vec__stop_words': None,
-            'y_batch_size': 512,
-            'model_path': model_path
-        }
-        train_and_evaluate(
-            train_data_path, label_binarizer_path, approach,
-            parameters=str(parameters),
-            model_path=model_path, sparse_labels=True)
-
-        model_artifacts = os.listdir(model_path)
-        assert len(model_artifacts) == math.ceil(5000 / 512) + 2 # (vectorizer, meta)
-
-
-def test_train_cnn_save():
-    approach = "mesh-cnn"
-
-    texts = ["one", "one two", "two"]
-    tags = [["one"], ["one","two"], ["two"]]
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
-        train_data_path = os.path.join(tmp_dir, "train_data.jsonl")
-
-        label_binarizer = MultiLabelBinarizer()
-        label_binarizer.fit(tags)
-        with open(label_binarizer_path, "wb") as label_binarizer_tmp:
-            label_binarizer_tmp.write(pickle.dumps(label_binarizer))
-
-        with open(train_data_path, "w") as train_data_tmp:
-            for text, tags_ in zip(texts, tags):
-                train_data_tmp.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
-                train_data_tmp.write("\n")
-
-        train_and_evaluate(train_data_tmp.name, label_binarizer_tmp.name,
-                           approach, model_path=tmp_dir)
-
-        expected_vectorizer_path = os.path.join(tmp_dir, "vectorizer.pkl")
-        expected_model_variables_path = os.path.join(tmp_dir, "variables")
-        expected_model_assets_path = os.path.join(tmp_dir, "assets")
-        assert os.path.exists(expected_vectorizer_path)
-        assert os.path.exists(expected_model_variables_path)
-        assert os.path.exists(expected_model_assets_path)
-
 
 def test_create_label_binarizer():
     texts = ["one", "one two", "two"]
@@ -150,6 +65,62 @@ def test_create_label_binarizer_sparse():
         assert isinstance(Y, csr_matrix)
 
 
+def test_train_and_evaluate():
+    approach = "tfidf-svm"
+
+    texts = ["one", "one two", "two"]
+    tags = [["one"], ["one", "two"], ["two"]]
+    with tempfile.NamedTemporaryFile("r+") as train_data_tmp:
+        label_binarizer = MultiLabelBinarizer()
+        label_binarizer.fit(tags)
+        with tempfile.NamedTemporaryFile() as label_binarizer_tmp:
+            label_binarizer_tmp.write(pickle.dumps(label_binarizer))
+
+            for text, tags_ in zip(texts, tags):
+                train_data_tmp.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
+                train_data_tmp.write("\n")
+
+            train_data_tmp.seek(0)
+            label_binarizer_tmp.seek(0)
+
+            train_and_evaluate(train_data_tmp.name, label_binarizer_tmp.name, approach,
+                               parameters="{'tfidf__min_df': 1, 'tfidf__stop_words': None}")
+
+
+def test_train_pickle_save():
+    pass
+
+def test_train_model_save():
+    approach = "mesh-cnn"
+
+    texts = ["one", "one two", "two"]
+    tags = [["one"], ["one","two"], ["two"]]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
+        train_data_path = os.path.join(tmp_dir, "train_data.jsonl")
+
+        label_binarizer = MultiLabelBinarizer()
+        label_binarizer.fit(tags)
+        with open(label_binarizer_path, "wb") as label_binarizer_tmp:
+            label_binarizer_tmp.write(pickle.dumps(label_binarizer))
+
+        with open(train_data_path, "w") as train_data_tmp:
+            for text, tags_ in zip(texts, tags):
+                train_data_tmp.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
+                train_data_tmp.write("\n")
+
+        train_and_evaluate(train_data_tmp.name, label_binarizer_tmp.name,
+                           approach, model_path=tmp_dir)
+
+        expected_vectorizer_path = os.path.join(tmp_dir, "vectorizer.pkl")
+        expected_model_variables_path = os.path.join(tmp_dir, "variables")
+        expected_model_assets_path = os.path.join(tmp_dir, "assets")
+        assert os.path.exists(expected_vectorizer_path)
+        assert os.path.exists(expected_model_variables_path)
+        assert os.path.exists(expected_model_assets_path)
+
+
 def test_train_and_evaluate_generator():
     approach = "mesh-cnn"
 
@@ -177,6 +148,7 @@ def test_train_and_evaluate_generator():
         train_and_evaluate(train_data_path, label_binarizer_path, approach,
                            data_format="generator", sparse_labels=True, test_data_path=test_data_path)
 
+
 def test_train_and_evaluate_generator_non_sparse_labels():
     approach = "mesh-cnn"
 
@@ -203,3 +175,40 @@ def test_train_and_evaluate_generator_non_sparse_labels():
         
         train_and_evaluate(train_data_path, label_binarizer_path, approach,
                            data_format="generator", test_data_path=test_data_path)
+
+
+def test_train_and_evaluate_threshold():
+    pass
+
+
+# TODO: Move to models
+def test_train_and_evaluate_y_batch_size():
+    approach = "mesh-tfidf-svm"
+
+    texts = ["one", "one two", "all"]
+    tags = [["1"], ["1", "2"], [str(i) for i in range(5000)]]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        label_binarizer_path = os.path.join(tmp_dir, "label_binarizer.pkl")
+        train_data_path = os.path.join(tmp_dir, "train_data.jsonl")
+        model_path = os.path.join(tmp_dir, "model")
+
+        with open(train_data_path, "w") as train_data_tmp:
+            for text, tags_ in zip(texts, tags):
+                train_data_tmp.write(json.dumps({"text": text, "tags": tags_, "meta": {}}))
+                train_data_tmp.write("\n")
+        
+        parameters = {
+            'vec__min_df': 1,
+            'vec__stop_words': None,
+            'y_batch_size': 512,
+            'model_path': model_path
+        }
+        train_and_evaluate(
+            train_data_path, label_binarizer_path, approach,
+            parameters=str(parameters),
+            model_path=model_path, sparse_labels=True)
+
+        model_artifacts = os.listdir(model_path)
+        assert len(model_artifacts) == math.ceil(5000 / 512) + 2 # (vectorizer, meta)
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,8 +12,6 @@ import pytest
 from grants_tagger.utils import (load_data, calc_performance_per_tag,   load_train_test_data)
 
 
-# TODO: Use fixtures to remove duplication
-
 @pytest.fixture
 def train_data_path(tmp_path):
     test_data = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,34 +51,17 @@ def test_data_path(tmp_path):
 
     return test_data_path
 
-# TODO: Refactor to use train_data_path and test_data_path
-
 @pytest.fixture
-def data_path(tmp_path):
-    test_data = [
-        {
-            'text': 'A',
-            'tags': ['T1', 'T2'],
-            'meta': {'Grant_ID': 1, 'Title': 'A'}
-        },
-        {
-            'text': 'B',
-            'tags': ['T1'],
-            'meta': {'Grant_ID': 2, 'Title': 'B'}
-        },
-        {
-            'text': 'C',
-            'tags': ['T2'],
-            'meta': {'Grant_ID': 3, 'Title': 'C'}
-        }
-    ]
-    test_data_path = os.path.join(tmp_path, "train_data.jsonl")
-    with open(test_data_path, 'w') as f:
-        for line in test_data:
-            f.write(json.dumps(line))
-            f.write('\n')
-
-    return test_data_path
+def data_path(tmp_path, train_data_path, test_data_path):
+    data_path = os.path.join(tmp_path, "data.jsonl")
+    with open(data_path, "w") as data_f:
+        with open(train_data_path, "r") as train_f:
+            for line in train_f:
+                data_f.write(line)
+        with open(test_data_path, "r") as test_f:
+            for line in test_f:
+                data_f.write(line)
+    return data_path
 
 @pytest.fixture
 def label_binarizer():


### PR DESCRIPTION
The main motivation for this PR was that pieces of the implementation that made production models happen was living in different scripts such as train, predict and evaluate. Those were custom adjustments that are not general enough to go to WellcomeML so they ended up in a semi organised way in the project. As progressively these adjustments are quite specific to the some models and in particular those that went to production, the logical thing to do was to introduce custom classes for the production models that hide away the complexity and expose a clean sklearn API such as WellcomeML. In order for this to happen a lot of code needed to move around and some needed to be rewritten hence the big size which as you can see does not introduce a lot of new lines but does move around a lot.

Production model adjustments that moved into classes
* y_batch_size was a parameter that was controlling batching in the Y vector in mesh tfidf svm and is now part of that model
* save and load is implemented inside the production classes
* the ensemble model has its own class which makes use of WellcomeVotingClassifier
* from_same_distribution is removed, only used in two configs and added non intuitive complexity

Other changes that are worth highlighting
* tests now use fixtures to reduce duplication
* load_train_test_data returns a list or generator and `data_format` in train controls that
* models save a meta file which can be used in the future to restore variables and know which model will be loaded
* scispacy does not need a separate installation since the latest WellcomeML uses spacy v3

Fixes #23
Fixes #24