### PR TITLE
Split data sync to science and mesh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ models/**
 **/*.xml
 **/*.csv
 **/*.json
+**/*.txt
 !results/*.json
 
 # Hidden files

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,15 @@ PYTHON := python3.8
 VIRTUALENV := venv
 PIP := $(VIRTUALENV)/bin/pip
 
-.PHONY:sync_data
-sync_data: ## Sync data to and from s3
-	aws s3 sync data/raw/ s3://$(PRIVATE_PROJECT_BUCKET)/data/raw/
-	aws s3 sync s3://$(PRIVATE_PROJECT_BUCKET)/data/raw data/raw --exclude "*allMeSH*"
+.PHONY:sync_science_data
+sync_science_data: ## Sync science data to and from s3
+	aws s3 sync data/raw/ s3://$(PRIVATE_PROJECT_BUCKET)/data/raw/ --exclude "*allMeSH*" --exclude "*desc*" --exclude "*disease_tags*"
+	aws s3 sync s3://$(PRIVATE_PROJECT_BUCKET)/data/raw data/raw --exclude "*allMeSH*" --exclude "*desc*" --exclude "*disease_tags*"
+
+.PHONY: sync_mesh_data
+sync_mesh_data: ## Sync mesh data to and from s3
+	aws s3 sync data/raw/ s3://$(PRIVATE_PROJECT_BUCKET)/data/raw/ --exclude "*" --include "*allMeSH*" --include "*desc*" --include "*disease_tags*"
+	aws s3 sync s3://$(PRIVATE_PROJECT_BUCKET)/data/raw data/raw/ --exclude "*" --include "*allMeSH*" --include "*desc*" --include "*disease_tags*"
 
 .PHONY: sync_artifacts
 sync_artifacts: ## Sync processed data and models to and from s3

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ PYTHON := python3.8
 VIRTUALENV := venv
 PIP := $(VIRTUALENV)/bin/pip
 
+
+.PHONY: sync_data
+sync_data: sync_science_data sync_mesh_data ## Sync data to and from s3
+
 .PHONY:sync_science_data
 sync_science_data: ## Sync science data to and from s3
 	aws s3 sync data/raw/ s3://$(PRIVATE_PROJECT_BUCKET)/data/raw/ --exclude "*allMeSH*" --exclude "*desc*" --exclude "*disease_tags*"

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,25 @@ sync_mesh_data: ## Sync mesh data to and from s3
 	aws s3 sync s3://$(PRIVATE_PROJECT_BUCKET)/data/raw data/raw/ --exclude "*" --include "*allMeSH*" --include "*desc*" --include "*disease_tags*"
 
 .PHONY: sync_artifacts
-sync_artifacts: ## Sync processed data and models to and from s3
+sync_artifacts: sync_science_artifacts sync_mesh_artifacts ## Sync processed data and models to and from s3
+
+.PHONY: sync_science_artifacts
+sync_science_artifacts: ## Sync science processed data and models
 	echo "Sync processed data"
-	aws s3 sync data/processed s3://$(PRIVATE_PROJECT_BUCKET)/data/processed 
-	aws s3 sync s3://$(PRIVATE_PROJECT_BUCKET)/data/processed data/processed
+	aws s3 sync data/processed s3://$(PRIVATE_PROJECT_BUCKET)/data/processed --exclude "*" --include "*science*" 
+	aws s3 sync s3://$(PRIVATE_PROJECT_BUCKET)/data/processed data/processed --exclude "*" --include "*science*"
 	echo "Sync models"
-	aws s3 sync models/ s3://$(PRIVATE_PROJECT_BUCKET)/models/
-	aws s3 sync s3://$(PRIVATE_PROJECT_BUCKET)/models/ models/
+	aws s3 sync models/ s3://$(PRIVATE_PROJECT_BUCKET)/models/ --exclude "*" --include "*science*"
+	aws s3 sync s3://$(PRIVATE_PROJECT_BUCKET)/models/ models/ --exclude "*" --include "*science*"
+
+.PHONY: sync_mesh_artifacts
+sync_mesh_artifacts: ## Sync mesh processed data and models
+	echo "Sync processed data"
+	aws s3 sync data/processed s3://$(PRIVATE_PROJECT_BUCKET)/data/processed --exclude "*" --include "*mesh*"
+	aws s3 sync s3://$(PRIVATE_PROJECT_BUCKET)/data/processed data/processed --exclude "*" --include "*mesh*"
+	echo "Sync models"
+	aws s3 sync models/ s3://$(PRIVATE_PROJECT_BUCKET)/models/ --exclude "*" --include "*mesh*"
+	aws s3 sync s3://$(PRIVATE_PROJECT_BUCKET)/models/ models/ --exclude "*" --include "*mesh*" --exclude "*tfidf*"
 
 virtualenv: ## Creates virtualenv
 	@if [ -d $(VIRTUALENV) ]; then rm -rf $(VIRTUALENV); fi

--- a/README.md
+++ b/README.md
@@ -390,7 +390,10 @@ values.
 If you work for Wellcome and have access to our AWS account,
 you easily download the raw data by typing `make sync_data`.
 This will give you access to both the custom science tags
-dataset and the MeSH data.
+dataset and the MeSH data. Note that the mesh data is 50+GB.
+If you want to download only the science or mesh data, you
+can do so with `make sync_science_data` and `make sync_mesh_data`
+respectively.
 
 The MeSH data can be downloaded from various places like EPMC.
 Grants tagger currently uses a sample provided from the [BioASQ](http://www.bioasq.org)

--- a/data/raw/allMeSH_2021.json.dvc
+++ b/data/raw/allMeSH_2021.json.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: e827a6b8062d1312664dcf075c12d89f
+  size: 27547042745
+  path: allMeSH_2021.json


### PR DESCRIPTION
As I was not able to find a way to use `dvc --glob` to selectively pull and push, I am adding a way for the user to control which data to sync as a separate make command. This way the user can choose to sync the mesh project or not.

`dvc pull` pulls all the data but since `dvc` is meant for production, that is not necessarily bad. A user can safely experiment with the make commands.