### PR TITLE
Add download EPMC script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ models/**
 **/*.csv
 **/*.json
 **/*.txt
+**/*.tmp
 !results/*.json
 
 # Hidden files

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Grants tagger comes with a nice CLI with the following commands
 | 🔖 tag          | tag grants using a pretrained model                          |
 | 🎛 tune         | tune params and threshold                                    |
 | 📚 pretrain     | pretrains embeddings or language model using unlabeled data  |
-| ⬇️ [download]    | download trained models and data from EPMC                   |
+| ⬇️  download   | download trained models and data from EPMC                   |
 | 🔍 [explain]    | importance of feature be it words or tfidf numbers           |
 | 🌐 visualize    | creates a streamlit app to interactively tag grants          |
 
@@ -380,8 +380,19 @@ Options:
 
 ### ⬇️  Download
 
-This command is under development. The goal is to be able to download
-pretrained models and data from sources like EPMC.
+This commands enables you to download mesh data from EPMC
+and pre trained models. The latter is still under development.
+
+```
+Usage: grants_tagger download [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  epmc-mesh
+  models
+```
 
 ### 🔍 Explain 
 

--- a/grants_tagger/__main__.py
+++ b/grants_tagger/__main__.py
@@ -24,6 +24,7 @@ from grants_tagger.tune_threshold import tune_threshold
 from grants_tagger.optimise_params import optimise_params
 from grants_tagger.train_with_sagemaker import train_with_sagemaker
 from grants_tagger.evaluate_mesh_on_grants import evaluate_mesh_on_grants
+from grants_tagger.download_epmc import download_epmc
 
 app = typer.Typer(add_completion=False)
 
@@ -359,10 +360,21 @@ def tag(
                label_binarizer_path, threshold)
 
 
-@app.command()
-def download():
-    # download models and data from public s3
+download_app = typer.Typer()
+
+@download_app.command()
+def epmc_mesh(
+        download_path: str = typer.Argument(..., help="path to directory where to download EPMC data"),
+        year: int = typer.Option(2020, help="year to download epmc publications")):
+    
+    download_epmc(download_path, year)
+
+@download_app.command()
+def models():
+    # downloads public trained models
     pass
+
+app.add_typer(download_app, name="download")
 
 
 @app.command()

--- a/grants_tagger/download_epmc.py
+++ b/grants_tagger/download_epmc.py
@@ -26,7 +26,7 @@ def _get_response(session, params):
 def yield_results(session, params):
     response_json = _get_response(session, params) 
 
-    results = response_json["resultList"]["result"] 
+    results = response_json["resultList"]["result"]
     while results:
         for result in results:
             yield result
@@ -49,14 +49,13 @@ def download_epmc(download_path, year=2020):
     year_path = os.path.join(download_path, str(year))
     os.makedirs(year_path, exist_ok=True)
     for month in range(12):
-        month = f"{month+1:02}"
-            
-        month_path = os.path.join(year_path, f"{month}.jsonl")
+        month_path = os.path.join(year_path, f"{month+1:02}.jsonl")
         if os.path.exists(month_path):
             print(f"Skipping because {month_path} exists. Delete if you want to redownload")
             continue
 
-        with open(month_path, "w") as f:
+        tmp_month_path = f"{month_path}.tmp"
+        with open(tmp_month_path, "w") as f:
             params = {
                 "query": f"(FIRST_PDATE:[{year}-{month}-01 TO {year}-{month}-31])",
                 "format": "json",
@@ -67,6 +66,5 @@ def download_epmc(download_path, year=2020):
             for result in tqdm(yield_results(session, params), total=hit_count, desc=f"Year {year} Month {month}"):
                 f.write(json.dumps(result))
                 f.write("\n")
+        os.rename(tmp_month_path, month_path)
 
-if __name__ == "__main__":
-    download_epmc("data/epmc/")

--- a/grants_tagger/download_epmc.py
+++ b/grants_tagger/download_epmc.py
@@ -1,0 +1,72 @@
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+from tqdm import tqdm
+import requests
+import json
+import os
+
+
+RETRY_PARAMETERS = {
+     'backoff_factor': 1.2,
+     'status_forcelist': [429, 500, 502, 503, 504],
+ }
+
+RETRY_BACKOFF_MAX = 310
+EPMC_SEARCH_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/search" 
+
+
+def _get_response(session, params):
+    response = session.get(
+        EPMC_SEARCH_URL,
+        params=params
+    )
+    response_json = response.json()
+    return response_json
+
+def yield_results(session, params):
+    response_json = _get_response(session, params) 
+
+    results = response_json["resultList"]["result"] 
+    while results:
+        for result in results:
+            yield result
+         
+        params['cursorMark'] = response_json.get("nextCursorMark") 
+        response_json = _get_response(session, params)
+
+        results = response_json["resultList"]["result"]
+
+def get_hit_count(session, params):
+    response_json = _get_response(session, params) 
+    return response_json["hitCount"] 
+
+def download_epmc(download_path, year=2020):
+    session = requests.Session()
+    retries = Retry(**RETRY_PARAMETERS)
+    retries.BACKOFF_MAX = RETRY_BACKOFF_MAX
+    session.mount('https://', HTTPAdapter(max_retries=retries))
+
+    year_path = os.path.join(download_path, str(year))
+    os.makedirs(year_path, exist_ok=True)
+    for month in range(12):
+        month = f"{month+1:02}"
+            
+        month_path = os.path.join(year_path, f"{month}.jsonl")
+        if os.path.exists(month_path):
+            print(f"Skipping because {month_path} exists. Delete if you want to redownload")
+            continue
+
+        with open(month_path, "w") as f:
+            params = {
+                "query": f"(FIRST_PDATE:[{year}-{month}-01 TO {year}-{month}-31])",
+                "format": "json",
+                "resultType": "core",
+                "pageSize": 100
+            }
+            hit_count = get_hit_count(session, params)
+            for result in tqdm(yield_results(session, params), total=hit_count, desc=f"Year {year} Month {month}"):
+                f.write(json.dumps(result))
+                f.write("\n")
+
+if __name__ == "__main__":
+    download_epmc("data/epmc/")

--- a/grants_tagger/download_epmc.py
+++ b/grants_tagger/download_epmc.py
@@ -49,7 +49,8 @@ def download_epmc(download_path, year=2020):
     year_path = os.path.join(download_path, str(year))
     os.makedirs(year_path, exist_ok=True)
     for month in range(12):
-        month_path = os.path.join(year_path, f"{month+1:02}.jsonl")
+        month = f"{month+1:02}"
+        month_path = os.path.join(year_path, f"{month}.jsonl")
         if os.path.exists(month_path):
             print(f"Skipping because {month_path} exists. Delete if you want to redownload")
             continue

--- a/tests/test_download_epmc.py
+++ b/tests/test_download_epmc.py
@@ -1,0 +1,61 @@
+from unittest import mock
+import json
+import os
+
+import pytest
+
+from grants_tagger.download_epmc import download_epmc, yield_results
+
+
+@pytest.fixture
+def download_path(tmp_path):
+    return tmp_path
+
+
+def create_month_data(month_path):
+    with open(month_path, "w") as f:
+        f.write(json.dumps({"item": "fake"}))
+        f.write("\n")
+
+@mock.patch('grants_tagger.download_epmc.get_hit_count', return_value=5)
+@mock.patch('grants_tagger.download_epmc.yield_results', return_value=["item"])
+def test_download_epmc(download_path, *mock_args):
+    year = 2020
+    download_epmc(download_path, year)
+    for month in range(12):
+        month_path = os.path.join(download_path, str(year), f"{month+1:02}.jsonl")
+        assert os.path.exists(month_path)
+
+
+@mock.patch('grants_tagger.download_epmc.get_hit_count', return_value=5)
+@mock.patch('grants_tagger.download_epmc.yield_results', return_value=["item"])
+def test_download_epmc_skip(download_path, *mock_args):
+    year = 2020
+    year_path = os.path.join(download_path, str(year))
+    os.makedirs(year_path)
+    month_path = os.path.join(year_path, f"01.jsonl")
+    create_month_data(month_path)
+    download_epmc(download_path, year)
+    with open(month_path) as f:
+        for line in f:
+            item = json.loads(line)
+            break
+    assert item["item"] == "fake"
+
+
+@mock.patch('grants_tagger.download_epmc.get_hit_count', return_value=5)
+@mock.patch('grants_tagger.download_epmc.yield_results', return_value=[{"item": "not fake"}])
+def test_download_redownload_tmp(download_path, *mock_args):
+    year = 2020
+    year_path = os.path.join(download_path, str(year))
+    os.makedirs(year_path)
+    month_path = os.path.join(year_path, f"01.jsonl")
+    tmp_month_path = f"{month_path}.tmp"
+    create_month_data(tmp_month_path)
+    download_epmc(download_path, year)
+    with open(month_path) as f:
+        for line in f:
+            item = json.loads(line)
+            break
+    assert item["item"] == "not fake"
+    

--- a/tests/test_download_epmc.py
+++ b/tests/test_download_epmc.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from grants_tagger.download_epmc import download_epmc, yield_results
+from grants_tagger.download_epmc import download_epmc
 
 
 @pytest.fixture
@@ -19,7 +19,7 @@ def create_month_data(month_path):
 
 @mock.patch('grants_tagger.download_epmc.get_hit_count', return_value=5)
 @mock.patch('grants_tagger.download_epmc.yield_results', return_value=["item"])
-def test_download_epmc(download_path, *mock_args):
+def test_download_epmc(mock_get_hit_count, mock_yield_results, download_path):
     year = 2020
     download_epmc(download_path, year)
     for month in range(12):
@@ -29,7 +29,7 @@ def test_download_epmc(download_path, *mock_args):
 
 @mock.patch('grants_tagger.download_epmc.get_hit_count', return_value=5)
 @mock.patch('grants_tagger.download_epmc.yield_results', return_value=["item"])
-def test_download_epmc_skip(download_path, *mock_args):
+def test_download_epmc_skip(mock_get_hit_count, mock_yield_results, download_path):
     year = 2020
     year_path = os.path.join(download_path, str(year))
     os.makedirs(year_path)
@@ -45,7 +45,7 @@ def test_download_epmc_skip(download_path, *mock_args):
 
 @mock.patch('grants_tagger.download_epmc.get_hit_count', return_value=5)
 @mock.patch('grants_tagger.download_epmc.yield_results', return_value=[{"item": "not fake"}])
-def test_download_redownload_tmp(download_path, *mock_args):
+def test_download_redownload_tmp(mock_get_hit_count, mock_yield_results, download_path):
     year = 2020
     year_path = os.path.join(download_path, str(year))
     os.makedirs(year_path)


### PR DESCRIPTION
This PR adds a `download` command to grants tagger so that the Mesh data can be downloaded from EPMC. The rationale is that BioASQ provides the data behind a registration whereas with EPMC it is freely available for all to download without the need to register.

I have copied and reimplemented the EPMC client as because of the volume of the data I needed it to write on the fly so that is more efficient and also handle partial downloads. If these are features we want in WellcomeML we can work towards bringing the two together in the future.

Fixes #54 