### PR TITLE
Download model command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 PRIVATE_PROJECT_BUCKET := $(PROJECTS_BUCKET)/$(PROJECT_NAME)
 PUBLIC_PROJECT_BUCKET := datalabs-public/$(PROJECT_NAME)
+MESH_MODEL := disease_mesh_cnn-2021.03.0
 
 PYTHON := python3.7
 VIRTUALENV := venv
@@ -79,7 +80,8 @@ deploy: ## Deploy wheel to public s3 bucket
 	git tag v$(shell python setup.py --version)
 	git push --tags
 	$(VIRTUALENV)/bin/python -m twine upload --repository pypi dist/*
-
+	tar -c -z -v -f models/$(MESH_MODEL).tar.gz models/$(MESH_MODEL)
+	gh release upload v$(shell python setup.py --version) models/$(MESH_MODEL).tar.gz
 .PHONY: clean
 clean: ## Clean hidden and compiled files
 	find . -type f -name "*.py[co]" -delete

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 PRIVATE_PROJECT_BUCKET := $(PROJECTS_BUCKET)/$(PROJECT_NAME)
 PUBLIC_PROJECT_BUCKET := datalabs-public/$(PROJECT_NAME)
 MESH_MODEL := disease_mesh_cnn-2021.03.0
+MESH_LABEL_BINARIZER := disease_mesh_label_binarizer.pkl
 
 PYTHON := python3.7
 VIRTUALENV := venv
@@ -80,7 +81,7 @@ deploy: ## Deploy wheel to public s3 bucket
 	git tag v$(shell python setup.py --version)
 	git push --tags
 	$(VIRTUALENV)/bin/python -m twine upload --repository pypi dist/*
-	tar -c -z -v -f models/$(MESH_MODEL).tar.gz models/$(MESH_MODEL)
+	tar -c -z -v -f models/$(MESH_MODEL).tar.gz models/$(MESH_MODEL) models/$(MESH_LABEL_BINARIZER)
 	gh release upload v$(shell python setup.py --version) models/$(MESH_MODEL).tar.gz
 .PHONY: clean
 clean: ## Clean hidden and compiled files

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ Options:
 ### ⬇️  Download
 
 This commands enables you to download mesh data from EPMC
-and pre trained models. The latter is still under development.
+and pre trained models.
 
 ```
 Usage: grants_tagger download [OPTIONS] COMMAND [ARGS]...
@@ -391,8 +391,12 @@ Options:
 
 Commands:
   epmc-mesh
-  models
+  model
 ```
+
+Available models:
+
+* disease_mesh
 
 ### 🔍 Explain 
 

--- a/grants_tagger/__main__.py
+++ b/grants_tagger/__main__.py
@@ -25,6 +25,7 @@ from grants_tagger.optimise_params import optimise_params
 from grants_tagger.train_with_sagemaker import train_with_sagemaker
 from grants_tagger.evaluate_mesh_on_grants import evaluate_mesh_on_grants
 from grants_tagger.download_epmc import download_epmc
+from grants_tagger.download_model import download_model
 
 app = typer.Typer(add_completion=False)
 
@@ -370,9 +371,8 @@ def epmc_mesh(
     download_epmc(download_path, year)
 
 @download_app.command()
-def models():
-    # downloads public trained models
-    pass
+def model(model_name: str = typer.Argument(..., help="model name to download e.g. disease_mesh")):
+    download_model(model_name)
 
 app.add_typer(download_app, name="download")
 

--- a/grants_tagger/download_model.py
+++ b/grants_tagger/download_model.py
@@ -7,7 +7,7 @@ import requests
 MODELS = {
     'disease_mesh': {
         'url': 'https://github.com/wellcometrust/grants_tagger/releases/download/v0.1.3/disease_mesh_cnn-2021.03.1.tar.gz',
-        'path': 'models/disease_mesh_cnn-2021.03.1.tar.gz'
+        'path': 'disease_mesh_cnn-2021.03.1.tar.gz'
     }
 }
 
@@ -29,7 +29,7 @@ def download_model(model_name):
     if model_name in MODELS:
         url = MODELS[model_name]['url']
         path = MODELS[model_name]['path']
-        models_path = os.path.join(os.path.dirname(__file__), '../models/')
+        models_path = os.path.join(os.path.dirname(__file__), '../')
         
         download_tar(url, path)
         untar(path, models_path)

--- a/grants_tagger/download_model.py
+++ b/grants_tagger/download_model.py
@@ -1,0 +1,40 @@
+import tarfile
+import os
+
+from tqdm import tqdm
+import requests
+
+MODELS = {
+    'disease_mesh': {
+        'url': 'https://github.com/wellcometrust/grants_tagger/releases/download/v0.1.3/disease_mesh_cnn-2021.03.1.tar.gz',
+        'path': 'models/disease_mesh_cnn-2021.03.1.tar.gz'
+    }
+}
+
+
+def download_tar(url, path):
+    response = requests.get(url, stream=True)
+    total_length = int(response.headers.get('content-length'))
+    
+    #iif response.status_code == 200:
+    with open(path, "wb") as f:
+        for chunk in tqdm(response.iter_content(chunk_size=1024), total=int(total_length / 1024), unit='KB'):
+            f.write(chunk)
+
+def untar(tar_path, path):
+    with tarfile.open(tar_path) as tar:
+        tar.extractall(path)
+
+def download_model(model_name):
+    if model_name in MODELS:
+        url = MODELS[model_name]['url']
+        path = MODELS[model_name]['path']
+        models_path = os.path.join(os.path.dirname(__file__), '../models/')
+        
+        download_tar(url, path)
+        untar(path, models_path)
+    else:
+        print(f"{model_name} not recognised. See README.md for list of models available")
+
+if __name__ == "__main__":
+    download_model("disease_mesh")

--- a/unpinned_requirements.txt
+++ b/unpinned_requirements.txt
@@ -17,3 +17,4 @@ python-dateutil<2.8.1,>=2.1
 twine
 sagemaker
 streamlit
+requests


### PR DESCRIPTION
Adds functionality to download publicly available models at the moment only `disease_mesh`. At the same time uploads those models when we do a new release.

Fixes #75 