### PR TITLE
Fix label binarizer path for tf-idf svm model

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -86,7 +86,7 @@ stages:
       size: 89
   evaluate_tfidf_svm:
     cmd: grants_tagger evaluate model tfidf-svm models/tfidf-svm-2020.05.2.pkl data/processed/science_grants_tagged_title_synopsis.jsonl
-      models/label_binarizer.pkl --results-path results/tfidf_svm.json
+      models/label_binarizer-2020.05.2.pkl --results-path results/tfidf_svm.json
     deps:
     - path: grants_tagger/evaluate_model.py
       md5: f44b129408d66916e59c881bc777db87

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -25,7 +25,7 @@ stages:
     - models/tfidf-svm-2020.05.2.pkl
   evaluate_tfidf_svm:
     cmd: grants_tagger evaluate model tfidf-svm models/tfidf-svm-2020.05.2.pkl data/processed/science_grants_tagged_title_synopsis.jsonl
-      models/label_binarizer.pkl --results-path results/tfidf_svm.json
+      models/label_binarizer-2020.05.2.pkl --results-path results/tfidf_svm.json
     deps:
     - grants_tagger/evaluate_model.py
     - models/label_binarizer-2020.05.2.pkl


### PR DESCRIPTION
Fixes #97. 

This doesn't change the results (exactly the same numbers as in `/results`).

I suspect the binarizer is _precisely_ the same, this change is just for consistency/to be pulled `dvc pull`.