### PR TITLE
Add flake8 github action

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,14 @@
+# Github action that runs flake8 check
+
+name: flake8-check
+on: [pull_request, push]
+jobs:
+  flake8-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install flake8
+        run: pip install flake8
+      - name: Run flake8
+        flake8 --ignore E501 grants_tagger

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Install flake8
         run: pip install flake8
       - name: Run flake8
-        flake8 --ignore E501 grants_tagger
+        run: flake8 --ignore E501 grants_tagger

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,7 +1,7 @@
 # Github action that runs flake8 check
 
 name: flake8-check
-on: [pull_request, push]
+on: pull_request
 jobs:
   flake8-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Adds Github action to run flake8 which fails if there are errors. The errors can be seen from the logs or by
running `flake8` locally

## Checklist

- [ ] Linked to Notion or GitHub issue
- [ ] Added tests
- [ ] Updated README
- [ ] DVC up to date
