### PR TITLE
Ligher grants_tagger

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         'pandas',
         'xlrd',
         'scikit-learn==0.23.2',
-        'nltk',
         'matplotlib',
         'wellcomeml[tensorflow]==1.2.0',
         'docutils==0.15',
@@ -26,10 +25,10 @@ setup(
         'wasabi',
         'typer',
         'scispacy',
-        'dvc',
         'tqdm',
-        'sagemaker',
-        'streamlit'
+        'streamlit',
+        'requests',
+        'pygtrie==2.3.3'
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
## Description

The intention of this PR was to make grants_tagger light as discussed
in #99 but this is not as easy as it sounds as `1.4GB` are simply the
size from solely `wellcomeml[tensorflow]==1.2.0` which is a core
dependency of this project.

As part of this PR I am removing uneeded packages (nltk) and those that
depend on our infrastructure which the user will not have access to like
dvc or sagemaker. At a later point we could provide indstruction as to how
to transition dvc and sagemaker functionality to their provided if needed. 

The package ends up taking `1.6GB`, `1.4GB` of which are, as mentioned from
`wellcomeml[tensorflow]==1.2.0`. Reducing futher will need to look into either
removing tensorflow or using a lite version of it.

Fixes #99
[Notion card](https://www.notion.so/wellcometrust/Make-grants-tagger-light-d085d1a8732c404dae91de70521c120f)

