### PR TITLE
Feature/script to pull new grants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,12 @@ build-streamlit-docker: ## Builds Docker with streamlit and models
 	aws s3 cp s3://datalabs-data/grants_tagger/models/label_binarizer.pkl models/
 	docker build -t streamlitapp -f Dockerfile.streamlit .
 
+.PHONY: install-private-requirements
+install-private-requirements: ## Install the private datascience utils
+	pip install pyodbc psycopg2
+	pip install -e git+ssh://git@github.com/wellcometrust/datascience.git#egg=wellcome-datascience-common
+ 
+
 help: ## Show help message
 	@IFS=$$'\n' ; \
 	help_lines=(`fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##/:/'`); \

--- a/data/raw/grants.csv.dvc
+++ b/data/raw/grants.csv.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 47506f6dd6a70345f581f79b23354749
-  size: 144744847
+- md5: 6889dfe605dac01e63ce0eb28697f055
+  size: 149738689
   path: grants.csv

--- a/data/raw/grants.csv.dvc
+++ b/data/raw/grants.csv.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: cf190c108ef5fe6da94f950eb4413b0f
-  size: 92592318
+- md5: 47506f6dd6a70345f581f79b23354749
+  size: 144744847
   path: grants.csv

--- a/data/raw/grants.csv.dvc
+++ b/data/raw/grants.csv.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 6889dfe605dac01e63ce0eb28697f055
-  size: 149738689
+- md5: e0ea1583139b78a540c383d22a061a89
+  size: 148758001
   path: grants.csv

--- a/scripts/get_grants.py
+++ b/scripts/get_grants.py
@@ -8,7 +8,7 @@ try:
 except ImportError as e:
     raise ImportError(f"Error importing {e.name }. "
                       f"To use this script you need to install Wellcome's datascience internal "
-                      f"utils.")
+                      f"utils, for example with `make install-private-requirements`")
 
 forty_two = FortyTwo()
 df = pd.DataFrame(forty_two.get_grants())

--- a/scripts/get_grants.py
+++ b/scripts/get_grants.py
@@ -1,0 +1,24 @@
+#!/bin/bash
+import pandas as pd
+
+import os
+
+from datascience.warehouse.warehouse import FortyTwo
+
+forty_two = FortyTwo()
+df = pd.DataFrame(forty_two.get_grants())
+
+columns_of_interest = [
+    'Cost Centre Division Name',
+    'Master Grant Type Name',
+    'Reference',
+    'Title',
+    'Synopsis',
+    'Lay Summary',
+    'Research Question',
+]
+
+here = os.path.abspath(os.path.dirname(__file__))
+df[columns_of_interest].to_csv(os.path.join(here, '../data/raw/grants.csv'))
+
+print(f"Downloaded {len(df)} grants")

--- a/scripts/get_grants.py
+++ b/scripts/get_grants.py
@@ -9,6 +9,7 @@ forty_two = FortyTwo()
 df = pd.DataFrame(forty_two.get_grants())
 
 columns_of_interest = [
+    'Grant ID',
     'Cost Centre Division Name',
     'Master Grant Type Name',
     'Reference',

--- a/scripts/get_grants.py
+++ b/scripts/get_grants.py
@@ -2,8 +2,13 @@
 import pandas as pd
 
 import os
-
-from datascience.warehouse.warehouse import FortyTwo
+try:
+    from datascience.warehouse.warehouse import FortyTwo
+    from datascience.grants.cleaning import clean_grants
+except ImportError as e:
+    raise ImportError(f"Error importing {e.name }. "
+                      f"To use this script you need to install Wellcome's datascience internal "
+                      f"utils.")
 
 forty_two = FortyTwo()
 df = pd.DataFrame(forty_two.get_grants())
@@ -13,11 +18,15 @@ columns_of_interest = [
     'Cost Centre Division Name',
     'Master Grant Type Name',
     'Reference',
+    'Start Date',
     'Title',
     'Synopsis',
     'Lay Summary',
     'Research Question',
 ]
+
+# Cleans grants to remove 'No data entered' and other things
+df = clean_grants(df)
 
 here = os.path.abspath(os.path.dirname(__file__))
 df[columns_of_interest].to_csv(os.path.join(here, '../data/raw/grants.csv'))

--- a/scripts/tag_grants_mesh_pipeline.sh
+++ b/scripts/tag_grants_mesh_pipeline.sh
@@ -1,7 +1,0 @@
-python /pipelines/mesh/task_tagger.py \ 
-	--input ../data/raw/grants.csv \
-	--output temp.csv \
-	--model_path models/xlinear/model \
-	--label_binarizer_path models/xlinear/label_binarizer.pkl \
-        --cap 100
-          

--- a/scripts/tag_grants_mesh_pipeline.sh
+++ b/scripts/tag_grants_mesh_pipeline.sh
@@ -1,0 +1,7 @@
+python /pipelines/mesh/task_tagger.py \ 
+	--input ../data/raw/grants.csv \
+	--output temp.csv \
+	--model_path models/xlinear/model \
+	--label_binarizer_path models/xlinear/label_binarizer.pkl \
+        --cap 100
+          


### PR DESCRIPTION
## Description

Towards: https://www.notion.so/wellcometrust/dc03328f311d4676b497ec7cd6f51042?v=e1a6758d760d4689b24356826b2d3541&p=b76ea39b19594ddbbc1c26182982d9d3

I added a script to update grants.csv file, but did not create a dvc.yaml stage for it, because it would block people that don't have access to `wellcometrust/datascience` (private repository) to run `dvc repro`

## Checklist

- [x] Linked to Notion or GitHub issue
- [ ] Added tests
- [ ] Updated README
- [ ] DVC up to date

## Release checklist

- [ ] DVC repro up to date
- [ ] Models synced in S3
- [ ] Version updated
- [ ] CHANGELOG.md updated
- [ ] Model and package version aligned

To release:

* `make build`
* `make deploy`

