### PR TITLE
Add label binarizer creation to the preprocess step

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,12 @@ your own data under development.
 ```
 Usage: grants_tagger preprocess wellcome-science [OPTIONS] [INPUT_PATH]
                                                  [OUTPUT_PATH]
+                                                 [LABEL_BINARIZER_PATH]
 
 Arguments:
   [INPUT_PATH]   path to raw Excel file with tagged or untagged grant data
   [OUTPUT_PATH]  path to JSONL output file that will be generated
+  [LABEL_BINARIZER_PATH] path to pickle file that will contain the label binarizer
 
 Options:
   --text-cols TEXT  comma delimited column names to concatenate to text
@@ -86,10 +88,12 @@ Options:
 ```
 Usage: grants_tagger preprocess bioasq-mesh [OPTIONS] [INPUT_PATH]
                                             [OUTPUT_PATH]
+                                            [LABEL_BINARIZER_PATH]
 
 Arguments:
   [INPUT_PATH]   path to BioASQ JSON data
   [OUTPUT_PATH]  path to output JSONL data
+  [LABEL_BINARIZER_PATH] path to pickle file that will contain the label binarizer
 
 Options:
   --mesh-tags-path TEXT      path to mesh tags to filter

--- a/grants_tagger/__main__.py
+++ b/grants_tagger/__main__.py
@@ -12,10 +12,12 @@ import time
 
 import typer
 
+
 logger = logging.getLogger(__name__)
 
 from grants_tagger.evaluate_mti import evaluate_mti
 from grants_tagger.evaluate_human import evaluate_human
+from grants_tagger.label_binarizer import create_label_binarizer
 from grants_tagger.pretrain import pretrain as pretrain_model
 from grants_tagger.evaluate_model import evaluate_model
 from grants_tagger.predict import predict_tags
@@ -176,6 +178,9 @@ preprocess_app = typer.Typer()
 def bioasq_mesh(
     input_path: Optional[str] = typer.Argument(None, help="path to BioASQ JSON data"),
     output_path: Optional[str] = typer.Argument(None, help="path to output JSONL data"),
+    label_binarizer_path: Optional[Path] = typer.Argument(
+        None, help="path to pickle file that will contain the label binarizer"
+    ),
     mesh_tags_path: Optional[str] = typer.Option(
         None, help="path to mesh tags to filter"
     ),
@@ -223,6 +228,7 @@ def bioasq_mesh(
     preprocess_mesh(
         input_path, output_path, mesh_tags_path=mesh_tags_path, test_split=test_split
     )
+    create_label_binarizer(output_path, label_binarizer_path)
 
 
 @preprocess_app.command()
@@ -232,6 +238,9 @@ def wellcome_science(
     ),
     output_path: Optional[Path] = typer.Argument(
         None, help="path to JSONL output file that will be generated"
+    ),
+    label_binarizer_path: Optional[Path] = typer.Argument(
+        None, help="path to pickle file that will contain the label binarizer"
     ),
     text_cols: Optional[str] = typer.Option(
         None, help="comma delimited column names to concatenate to text"
@@ -272,6 +281,11 @@ def wellcome_science(
         print(f"{output_path} exists. Remove if you want to rerun.")
     else:
         preprocess(input_path, output_path, text_cols, meta_cols)
+
+    if os.path.exists(label_binarizer_path):
+        print(f"{label_binarizer_path} exists. Remove if you want to rerun.")
+    else:
+        create_label_binarizer(output_path, label_binarizer_path)
 
 
 app.add_typer(preprocess_app, name="preprocess")

--- a/grants_tagger/label_binarizer.py
+++ b/grants_tagger/label_binarizer.py
@@ -1,0 +1,32 @@
+import argparse
+import pickle
+
+from pathlib import Path
+from sklearn.preprocessing import MultiLabelBinarizer
+
+from grants_tagger.utils import yield_tags
+
+
+def create_label_binarizer(data_path, label_binarizer_path, sparse=False):
+    """Creates, saves and returns a multilabel binarizer for targets Y"""
+    label_binarizer = MultiLabelBinarizer(sparse_output=sparse)
+    # TODO: pass Y_train here which can be generator or list
+    label_binarizer.fit(yield_tags(data_path))
+
+    with open(label_binarizer_path, "wb") as f:
+        f.write(pickle.dumps(label_binarizer))
+
+    return label_binarizer
+
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument("--data_path", type=Path)
+    argparser.add_argument("--label_binarizer_path", type=Path)
+    argparser.add_argument("--sparse_labels", type=bool)
+
+    args = argparser.parse_args()
+
+    create_label_binarizer(
+        args.data_path, args.label_binarizer_path, sparse_labels=args.sparse_labels
+    )

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -12,8 +12,8 @@ import json
 import ast
 
 from sklearn.metrics import f1_score, classification_report
-from sklearn.preprocessing import MultiLabelBinarizer
 
+from grants_tagger.label_binarizer import create_label_binarizer
 from grants_tagger.models.create_model import create_model
 from grants_tagger.utils import load_train_test_data, yield_tags
 
@@ -22,18 +22,6 @@ from tensorflow.random import set_seed
 # TODO: Remove when WellcomeML implements setting random_seed inside models
 # replace with param in configs then
 set_seed(41)
-
-
-def create_label_binarizer(data_path, label_binarizer_path, sparse=False):
-    """Creates, saves and returns a multilabel binarizer for targets Y"""
-    label_binarizer = MultiLabelBinarizer(sparse_output=sparse)
-    # TODO: pass Y_train here which can be generator or list
-    label_binarizer.fit(yield_tags(data_path))
-
-    with open(label_binarizer_path, "wb") as f:
-        f.write(pickle.dumps(label_binarizer))
-
-    return label_binarizer
 
 
 def train(


### PR DESCRIPTION
## Description
Move the create_label_binarizer() in it's own file. Add it to the preprocess step as there was no way of using it through the CLI before.

## Checklist

- [ ] Linked to Notion or GitHub issue
- [ ] Added tests
- [ x ] Updated README
- [ ] DVC up to date

## Release checklist

- [ ] DVC repro up to date
- [ ] Models synced in S3
- [ ] Version updated
- [ ] CHANGELOG.md updated
- [ ] Model and package version aligned

To release:

* `make build`
* `make deploy`

