### PR TITLE
Add year, journal in preprocess mesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,20 +89,31 @@ Options:
 #### bioasq-mesh
 ```
 Usage: grants_tagger preprocess bioasq-mesh [OPTIONS] [INPUT_PATH]
-                                            [OUTPUT_PATH]
+                                            [TRAIN_OUTPUT_PATH]
                                             [LABEL_BINARIZER_PATH]
 
 Arguments:
-  [INPUT_PATH]   path to BioASQ JSON data
-  [TRAIN_OUTPUT_PATH]  path to JSONL output file that will be generated for the train set
-  [LABEL_BINARIZER_PATH] path to pickle file that will contain the label binarizer
+  [INPUT_PATH]            path to BioASQ JSON data
+  [TRAIN_OUTPUT_PATH]     path to JSONL output file that will be generated for
+                          the train set
+
+  [LABEL_BINARIZER_PATH]  path to pickle file that will contain the label
+                          binarizer
+
 
 Options:
-  --test-output-path PATH    path to JSONL output file that will be generated for the test set
-  --mesh-tags-path TEXT      path to mesh tags to filter
-  --test-split FLOAT         split percentage for test data. if None no split.
-  --config PATH              path to config files that defines arguments
-  --help                     Show this message and exit.
+  --test-output-path TEXT  path to JSONL output file that will be generated
+                           for the test set
+
+  --mesh-tags-path TEXT    path to mesh tags to filter
+  --test-split FLOAT       split percentage for test data. if None no split.
+                           [default: 0.01]
+
+  --filter-years TEXT      years to keep in form min_year,max_year with both
+                           inclusive
+
+  --config PATH            path to config files that defines arguments
+  --help                   Show this message and exit.
 ```
 
 ### 🔥 Train

--- a/dvc.lock
+++ b/dvc.lock
@@ -54,8 +54,8 @@ stages:
       md5: 2fb37d57daeece50a0190e16e229647a
       size: 2809039
     - path: grants_tagger/train.py
-      md5: b43b3d12a59afff02b344082039fe4e0
-      size: 5908
+      md5: 7ad0632959accc481d8d5300f3c9fd84
+      size: 5996
     params:
       params.yaml:
         train.tfidf-svm.svm__estimator.class_weight: balanced
@@ -65,11 +65,11 @@ stages:
         - 2
     outs:
     - path: models/tfidf-svm.pkl
-      md5: fb7e7b95240330b8a8976336f31e7bce
+      md5: 32731569abad904c1780784370a61d68
       size: 17768857
     - path: results/tfidf_svm_train_info.json
-      md5: 113b3940028bdebb9b1f7800d0c05c82
-      size: 31
+      md5: 9b0b29b3885289675175896958c7ebfc
+      size: 62
   evaluate:
     cmd: grants_tagger evaluate model tfidf-svm models/tfidf-svm-2020.05.2.pkl data/processed/science_grants_tagged_title_synopsis.jsonl
       models/label_binarizer.pkl
@@ -98,11 +98,11 @@ stages:
       md5: 220319a004a60bd6475e2fb617c2c1f3
       size: 1067
     - path: models/tfidf-svm.pkl
-      md5: fb7e7b95240330b8a8976336f31e7bce
+      md5: 32731569abad904c1780784370a61d68
       size: 17768857
     outs:
     - path: results/tfidf_svm.json
-      md5: 45d09c717c170cfbe14bddc17965511c
+      md5: f4a61e7af633056482e7d035e75cb658
       size: 76
   train_scibert:
     cmd: grants_tagger train data/processed/science_grants_tagged_title_synopsis.jsonl
@@ -112,8 +112,8 @@ stages:
       md5: 2fb37d57daeece50a0190e16e229647a
       size: 2809039
     - path: grants_tagger/train.py
-      md5: b43b3d12a59afff02b344082039fe4e0
-      size: 5908
+      md5: 7ad0632959accc481d8d5300f3c9fd84
+      size: 5996
     params:
       params.yaml:
         train.scibert.epochs: 10
@@ -121,7 +121,7 @@ stages:
         train.scibert.validation_split: 0.1
     outs:
     - path: models/scibert
-      md5: 3fe73a519aabacf8c72501f8cd0c4ffc.dir
+      md5: 5cf7e7f8e11a1e00d1c214d637618b85.dir
       size: 440020006
       nfiles: 2
   evaluate_scibert:
@@ -135,7 +135,7 @@ stages:
       md5: 220319a004a60bd6475e2fb617c2c1f3
       size: 1067
     - path: models/scibert
-      md5: 3fe73a519aabacf8c72501f8cd0c4ffc.dir
+      md5: 5cf7e7f8e11a1e00d1c214d637618b85.dir
       size: 440020006
       nfiles: 2
     outs:
@@ -150,15 +150,15 @@ stages:
       md5: e827a6b8062d1312664dcf075c12d89f
       size: 27547042745
     - path: grants_tagger/preprocess_mesh.py
-      md5: 0a57c8ec31d0518ae350c9d856718d48
-      size: 4228
+      md5: 53a1d5c75d81c058bb667e9f7360bb7d
+      size: 5124
     outs:
     - path: data/processed/test_mesh2021.jsonl
-      md5: 9de03e6c3768c6918421a46fc908bb9b
-      size: 247324489
+      md5: 2d6f73d29ec6f98a3cae6df2c618f077
+      size: 257607574
     - path: data/processed/train_mesh2021.jsonl
-      md5: cd452731d4d4d9a6e30c5483a9490404
-      size: 24471990205
+      md5: 3fb0ddb59e11c40c0c34fd104b1815fb
+      size: 25488153802
     - path: models/xlinear/label_binarizer.pkl
       md5: 67d759ed4142feab2e575dc9bd3d5f54
       size: 827793
@@ -174,15 +174,15 @@ stages:
       md5: 220319a004a60bd6475e2fb617c2c1f3
       size: 1067
     - path: models/scibert
-      md5: 3fe73a519aabacf8c72501f8cd0c4ffc.dir
+      md5: 5cf7e7f8e11a1e00d1c214d637618b85.dir
       size: 440020006
       nfiles: 2
     - path: models/tfidf-svm.pkl
-      md5: fb7e7b95240330b8a8976336f31e7bce
+      md5: 32731569abad904c1780784370a61d68
       size: 17768857
     outs:
     - path: results/science_ensemble.json
-      md5: 9e4eddea3f996c92d0fd4208bf0d4117
+      md5: 5a4e3ab1af337aa42d2150cf9ec97abb
       size: 76
   train_mesh_cnn:
     cmd: grants_tagger train data/processed/disease_mesh.jsonl models/disease_mesh_label_binarizer-2021.06.0.pkl
@@ -235,14 +235,14 @@ stages:
       models/xlinear/model --approach mesh-xlinear --sparse-labels --train-info results/mesh_xlinear_train_info.json
     deps:
     - path: data/processed/test_mesh2021.jsonl
-      md5: 9de03e6c3768c6918421a46fc908bb9b
-      size: 247324489
+      md5: 2d6f73d29ec6f98a3cae6df2c618f077
+      size: 257607574
     - path: grants_tagger/models/mesh_xlinear.py
       md5: 5bac8a0913d841a6cfc146577805cb34
       size: 5140
     - path: grants_tagger/train.py
-      md5: b43b3d12a59afff02b344082039fe4e0
-      size: 5908
+      md5: 7ad0632959accc481d8d5300f3c9fd84
+      size: 5996
     params:
       params.yaml:
         train.mesh-xlinear.beam_size: 10
@@ -260,7 +260,7 @@ stages:
         train.mesh-xlinear.stop_words: english
     outs:
     - path: models/xlinear/model
-      md5: ed93cb6c7cb412f5126c631bd25cdc49.dir
+      md5: 072d18f207a503c632e0ce7f363da070.dir
       size: 3740297256
       nfiles: 33
   evaluate_mesh_xlinear_on_grants:
@@ -281,7 +281,7 @@ stages:
       md5: 67d759ed4142feab2e575dc9bd3d5f54
       size: 827793
     - path: models/xlinear/model
-      md5: ed93cb6c7cb412f5126c631bd25cdc49.dir
+      md5: 072d18f207a503c632e0ce7f363da070.dir
       size: 3740297256
       nfiles: 33
     outs:
@@ -300,7 +300,7 @@ stages:
       md5: 67d759ed4142feab2e575dc9bd3d5f54
       size: 827793
     - path: models/xlinear/model
-      md5: ed93cb6c7cb412f5126c631bd25cdc49.dir
+      md5: 072d18f207a503c632e0ce7f363da070.dir
       size: 3740297256
       nfiles: 33
     outs:

--- a/grants_tagger/__main__.py
+++ b/grants_tagger/__main__.py
@@ -1,4 +1,5 @@
 from grants_tagger.cli import app
 
+
 if __name__ == "__main__":
     app(prog_name="grants_tagger")

--- a/grants_tagger/preprocess_mesh.py
+++ b/grants_tagger/preprocess_mesh.py
@@ -20,6 +20,8 @@ from grants_tagger.utils import write_jsonl, verify_if_paths_exist
 from grants_tagger.label_binarizer import create_label_binarizer
 from grants_tagger.split_data import split_data
 
+import typer
+
 
 def yield_raw_data(input_path):
     with open(input_path, encoding="latin-1") as f_i:
@@ -32,11 +34,13 @@ def yield_raw_data(input_path):
 def process_data(item, filter_tags=None):
     text = item["abstractText"]
     tags = item["meshMajor"]
+    journal = item["journal"]
+    year = item["year"]
     if filter_tags:
         tags = list(set(tags).intersection(filter_tags))
     if not tags:
         return
-    data = {"text": text, "tags": tags, "meta": {}}
+    data = {"text": text, "tags": tags, "meta": {"journal": journal, "year": year}}
     return data
 
 
@@ -134,4 +138,4 @@ def preprocess_mesh_cli(
 
 
 if __name__ == "__main__":
-    preprocess_mesh_app()
+    typer.run(preprocess_mesh)

--- a/grants_tagger/preprocess_mesh.py
+++ b/grants_tagger/preprocess_mesh.py
@@ -106,6 +106,9 @@ def preprocess_mesh_cli(
     test_split: Optional[float] = typer.Option(
         0.01, help="split percentage for test data. if None no split."
     ),
+    filter_years: Optional[str] = typer.Option(
+        None, help="years to keep in form min_year,max_year with both inclusive"
+    ),
     config: Optional[Path] = typer.Option(
         None, help="path to config files that defines arguments"
     ),
@@ -119,6 +122,10 @@ def preprocess_mesh_cli(
     if not mesh_tags_path:
         mesh_tags_path = params["preprocess_bioasq_mesh"].get("mesh_tags_path")
 
+    # Default value from params
+    if not filter_years:
+        filter_years = params["preprocess_bioasq_mesh"].get("filter_years")
+
     if config:
         cfg = configparser.ConfigParser()
         cfg.read(config)
@@ -127,6 +134,7 @@ def preprocess_mesh_cli(
         train_output_path = cfg["preprocess"]["output"]
         mesh_tags_path = cfg["filter_mesh"].get("mesh_tags_path")
         test_split = cfg["preprocess"].getfloat("test_split")
+        filter_years = cfg["preprocess"].get("filter_years")
 
     if verify_if_paths_exist(
         [
@@ -138,7 +146,12 @@ def preprocess_mesh_cli(
         return
 
     temporary_output_path = train_output_path + ".tmp"
-    preprocess_mesh(input_path, temporary_output_path, mesh_tags_path=mesh_tags_path)
+    preprocess_mesh(
+        input_path,
+        temporary_output_path,
+        mesh_tags_path=mesh_tags_path,
+        filter_years=filter_years,
+    )
     create_label_binarizer(temporary_output_path, label_binarizer_path, sparse=True)
 
     if test_output_path:

--- a/grants_tagger/train.py
+++ b/grants_tagger/train.py
@@ -27,7 +27,7 @@ from grants_tagger.models.create_model import create_model
 from grants_tagger.utils import load_train_test_data, yield_tags
 
 from tensorflow.random import set_seed
-from grants_tagger.utils import convert_dvc_to_sklearn_params
+from grants_tagger.utils import convert_dvc_to_sklearn_params, get_ec2_instance_type
 
 
 # TODO: Remove when WellcomeML implements setting random_seed inside models
@@ -166,10 +166,11 @@ def train_cli(
         )
 
     duration = time.time() - start
+    instance = get_ec2_instance_type()
     print(f"Took {duration:.2f} to train")
     if train_info:
         with open(train_info, "w") as f:
-            json.dump({"duration": duration}, f)
+            json.dump({"duration": duration, "ec2_instance": instance}, f)
 
 
 if __name__ == "__main__":

--- a/results/mesh_xlinear_train_info.json
+++ b/results/mesh_xlinear_train_info.json
@@ -1,1 +1,1 @@
-{"duration": 4103.607721567154}
+{"duration": 4100.938353300095, "ec2_instance": "g4dn.metal"}

--- a/results/scibert_train_info.json
+++ b/results/scibert_train_info.json
@@ -1,1 +1,1 @@
-{"duration": 1304.6907510757446}
+{"duration": 1288.521588087082, "ec2_instance": "g4dn.metal"}

--- a/results/science_ensemble.json
+++ b/results/science_ensemble.json
@@ -1,1 +1,1 @@
-[{"threshold": "0.50", "precision": "0.84", "recall": "0.67", "f1": "0.74"}]
+[{"threshold": "0.50", "precision": "0.83", "recall": "0.67", "f1": "0.74"}]

--- a/results/tfidf_svm.json
+++ b/results/tfidf_svm.json
@@ -1,1 +1,1 @@
-[{"threshold": "0.50", "precision": "0.79", "recall": "0.62", "f1": "0.69"}]
+[{"threshold": "0.50", "precision": "0.80", "recall": "0.61", "f1": "0.69"}]

--- a/results/tfidf_svm_train_info.json
+++ b/results/tfidf_svm_train_info.json
@@ -1,1 +1,1 @@
-{"duration": 60.73383951187134}
+{"duration": 60.632452964782715, "ec2_instance": "g4dn.metal"}

--- a/tests/test_preprocess_mesh.py
+++ b/tests/test_preprocess_mesh.py
@@ -83,3 +83,14 @@ def test_process_data_with_filter_years():
     }
     processed_item = process_data(item, filter_years="2019,2020")
     assert processed_item == None
+    item["year"] = 2020
+    expected_processed_item = {
+        "text": "This is an abstract",
+        "tags": ["T1", "T2"],
+        "meta": {
+            "journal": "Journal",
+            "year": 2020
+        }
+    }
+    processed_item = process_data(item, filter_years="2019,2020")
+    assert processed_item == expected_processed_item

--- a/tests/test_preprocess_mesh.py
+++ b/tests/test_preprocess_mesh.py
@@ -8,7 +8,9 @@ from grants_tagger.preprocess_mesh import process_data, preprocess_mesh
 def test_preprocess_mesh():
     item = {
         "abstractText": "This is an abstract",
-        "meshMajor": ["T1", "T2"]
+        "meshMajor": ["T1", "T2"],
+        "journal": "Journal",
+        "year": 2018
     }
     with tempfile.NamedTemporaryFile(mode="r+") as input_tmp:
         input_tmp.write("\n"+json.dumps(item)+", ")
@@ -19,19 +21,27 @@ def test_preprocess_mesh():
     expected_processed_item = {
         "text": "This is an abstract",
         "tags": ["T1", "T2"],
-        "meta": {}
+        "meta": {
+            "journal": "Journal",
+            "year": 2018
+        }
     }
     assert output_tmp.read() == json.dumps(expected_processed_item) + "\n" 
 
 def test_process_data():
     item = {
         "abstractText": "This is an abstract",
-        "meshMajor": ["T1", "T2"]
+        "meshMajor": ["T1", "T2"],
+        "journal": "Journal",
+        "year": 2018
     }
     expected_processed_item = {
         "text": "This is an abstract",
         "tags": ["T1", "T2"],
-        "meta": {}
+        "meta": {
+            "journal": "Journal",
+            "year": 2018
+        }
     }
     processed_item = process_data(item)
     assert processed_item == expected_processed_item
@@ -39,12 +49,17 @@ def test_process_data():
 def test_process_data_with_filter_tags():
     item = {
         "abstractText": "This is an abstract",
-        "meshMajor": ["T1", "T2"]
+        "meshMajor": ["T1", "T2"],
+        "journal": "Journal",
+        "year": 2018
     }
     expected_processed_item = {
         "text": "This is an abstract",
         "tags": ["T1"],
-        "meta": {}
+        "meta": {
+            "journal": "Journal",
+            "year": 2018
+        }
     }
     processed_item = process_data(item, filter_tags=["T1"])
     assert processed_item == expected_processed_item
@@ -52,7 +67,19 @@ def test_process_data_with_filter_tags():
 def test_process_data_with_missing_filter_tag():
     item = {
         "abstractText": "This is an abstract",
-        "meshMajor": ["T1", "T2"]
+        "meshMajor": ["T1", "T2"],
+        "journal": "Journal",
+        "year": 2018
     }
     processed_item = process_data(item, filter_tags=["T3"])
+    assert processed_item == None
+
+def test_process_data_with_filter_years():
+    item = {
+        "abstractText": "This is an abstract",
+        "meshMajor": ["T1", "T2"],
+        "journal": "Journal",
+        "year": 2018
+    }
+    processed_item = process_data(item, filter_years="2019,2020")
     assert processed_item == None


### PR DESCRIPTION
## Description

Both #173 and #160 require a subset of the data to train. The best possible way to provide that subset is to filter by years which is standard practice in this problem. At the moment this is implemented in both PR mentioned but this aims to resolve it for both.

Fixes #109

## Checklist

- [x] Linked to Notion or GitHub issue
- [x] Added tests
- [x] Updated README
- [ ] DVC up to date

