### PR TITLE
Add BertMesh to models so that we can tag in BioASQ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SCIENCE_TFIDF_SVM_MODEL:= tfidf-svm.pkl
 SCIENCE_SCIBERT_MODEL := scibert
 SCIENCE_LABEL_BINARIZER := label_binarizer.pkl
 
-PYTHON := python3.8
+PYTHON := python3.7
 VIRTUALENV := venv
 PIP := $(VIRTUALENV)/bin/pip
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SCIENCE_TFIDF_SVM_MODEL:= tfidf-svm.pkl
 SCIENCE_SCIBERT_MODEL := scibert
 SCIENCE_LABEL_BINARIZER := label_binarizer.pkl
 
-PYTHON := python3.7
+PYTHON := python3
 VIRTUALENV := venv
 PIP := $(VIRTUALENV)/bin/pip
 

--- a/README.md
+++ b/README.md
@@ -502,7 +502,8 @@ expected in the future when newer versions will have been published.
 
 ## 📋 Env variables
 
-You need to set the following variables for sagemaker or sync to work.
+You need to set the following variables for sagemaker or sync to work. If you want to
+participate to BIOASQ competition you need to also set some variables.
 
 Variable              | Required for       | Description
 --------------------- | ------------------ | ----------
@@ -513,6 +514,8 @@ ECR_IMAGE             | sagemaker          | ecr image with dependencies to run 
 SAGEMAKER_ROLE        | sagemaker          | aws sagemaker role, ask aws administrator
 AWS_ACCESS_KEY_ID     | sagemaker, sync    | aws access key, for aws cli to work
 AWS_SECRET_ACCESS_KEY | sagemaker, sync    | aws secret key, for aws cli to work
+BIOASQ_USERNAME       | bioasq             | username with which registered in BioASQ
+BIOASQ_PASSWORD       | bioasq             | password            --//--
 
 There is a `.envrc.template` with the env variables needed. If you
 use [direnv](https://direnv.net) then you can use it to populate

--- a/grants_tagger/models/bert_mesh.py
+++ b/grants_tagger/models/bert_mesh.py
@@ -1,0 +1,55 @@
+from transformers import BertTokenizerFast
+from torch.utils.data import Dataset, DataLoader
+from tqdm import tqdm
+import scipy.sparse as sp
+import numpy as np
+import torch
+
+from grants_tagger.bertmesh.model import BertMesh
+
+class MeshDataset(Dataset):
+    def __init__(self, X):
+        self.tokenizer = BertTokenizerFast.from_pretrained("bert-base-uncased")
+        self.input_ids = self.tokenizer(X, truncation=True, padding=True)["input_ids"]
+
+    def __len__(self):
+        return len(self.input_ids)
+
+    def __getitem__(self, idx):
+        return torch.tensor(self.input_ids[idx])
+
+class WellcomeBertMesh():
+    def __init__(self, cutoff_prob=0.1, threshold=0.5, batch_size=16):
+        self.cutoff_prob=cutoff_prob
+        self.threshold = threshold
+        self.batch_size = batch_size
+
+    def predict(self, X):
+        return self.predict_proba(X) > self.threshold
+
+    def predict_proba(self, X):
+        dataset = MeshDataset(X)
+        data = DataLoader(dataset, self.batch_size)
+
+        self.model.eval()
+
+        Y_pred_proba = []
+        with torch.no_grad():
+            for inputs in tqdm(data):
+                outs = self.model(inputs)
+
+                Y_pred_proba_batch = outs.cpu().numpy()
+                Y_pred_proba_batch[Y_pred_proba_batch < self.cutoff_prob] = 0
+                Y_pred_proba.append(sp.csr_matrix(Y_pred_proba_batch))
+
+        Y_pred_proba = sp.vstack(Y_pred_proba)
+        return Y_pred_proba
+
+    def load(self, model_path):
+        self.model = BertMesh(
+            pretrained_model="microsoft/BiomedNLP-PubMedBERT-base-uncased-abstract",
+            num_labels=28761,
+            hidden_size=1024,
+            multilabel_attention=True
+        )
+        self.model.load_state_dict(torch.load(model_path, map_location=torch.device('cpu')).module.state_dict())

--- a/grants_tagger/models/bert_mesh.py
+++ b/grants_tagger/models/bert_mesh.py
@@ -54,6 +54,9 @@ class WellcomeBertMesh:
             hidden_size=1024,
             multilabel_attention=True,
         )
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model.load_state_dict(
-            torch.load(model_path, map_location=torch.device("cpu")).module.state_dict()
+            torch.load(
+                model_path, map_location=torch.device(device)
+            ).module.state_dict()
         )

--- a/grants_tagger/models/bert_mesh.py
+++ b/grants_tagger/models/bert_mesh.py
@@ -7,6 +7,7 @@ import torch
 
 from grants_tagger.bertmesh.model import BertMesh
 
+
 class MeshDataset(Dataset):
     def __init__(self, X):
         self.tokenizer = BertTokenizerFast.from_pretrained("bert-base-uncased")
@@ -18,9 +19,10 @@ class MeshDataset(Dataset):
     def __getitem__(self, idx):
         return torch.tensor(self.input_ids[idx])
 
-class WellcomeBertMesh():
+
+class WellcomeBertMesh:
     def __init__(self, cutoff_prob=0.1, threshold=0.5, batch_size=16):
-        self.cutoff_prob=cutoff_prob
+        self.cutoff_prob = cutoff_prob
         self.threshold = threshold
         self.batch_size = batch_size
 
@@ -50,6 +52,8 @@ class WellcomeBertMesh():
             pretrained_model="microsoft/BiomedNLP-PubMedBERT-base-uncased-abstract",
             num_labels=28761,
             hidden_size=1024,
-            multilabel_attention=True
+            multilabel_attention=True,
         )
-        self.model.load_state_dict(torch.load(model_path, map_location=torch.device('cpu')).module.state_dict())
+        self.model.load_state_dict(
+            torch.load(model_path, map_location=torch.device("cpu")).module.state_dict()
+        )

--- a/grants_tagger/models/create_model.py
+++ b/grants_tagger/models/create_model.py
@@ -40,6 +40,7 @@ from grants_tagger.models.mesh_cnn import MeshCNN
 from grants_tagger.models.tfidf_transformers_svm import TfidfTransformersSVM
 from grants_tagger.models.science_ensemble import ScienceEnsemble
 from grants_tagger.models.mesh_tfidf_svm import MeshTfidfSVM
+from grants_tagger.models.bert_mesh import WellcomeBertMesh
 from grants_tagger.utils import save_pickle, load_pickle
 from wellcomeml.ml.bilstm import BiLSTMClassifier
 from wellcomeml.ml.cnn import CNNClassifier
@@ -478,6 +479,8 @@ def create_model(approach, parameters=None):
         model = ScienceEnsemble()
     elif approach == "mesh-xlinear":
         model = MeshXLinear()
+    elif approach == "bertmesh":
+        model = WellcomeBertMesh()
     else:
         raise ApproachNotImplemented
     if parameters:

--- a/pipelines/bioasq/dvc.lock
+++ b/pipelines/bioasq/dvc.lock
@@ -1,15 +1,15 @@
 schema: '2.0'
 stages:
   download:
-    cmd: python ../../scripts/download_bioasq_test_data.py 3 ../../data/processed/bioasq/data_3.json
+    cmd: python ../../scripts/download_bioasq_test_data.py 7 ../../data/processed/bioasq/data_7.json
     deps:
     - path: ../../scripts/download_bioasq_test_data.py
       md5: dd7b13b49437977d68fee317acf4499d
       size: 528
     outs:
-    - path: ../../data/processed/bioasq/data_3.json
-      md5: ec91b529f6e8464255603001bed995c4
-      size: 7694765
+    - path: ../../data/processed/bioasq/data_7.json
+      md5: 1b83feb67dfaada7ea87b396fe6e4deb
+      size: 182
   tag:
     cmd: python ../../scripts/tag_bioasq_test_data.py ../../data/processed/bioasq/data_3.json
       ../../models/xlinear/model/ ../../models/xlinear/label_binarizer.pkl ../../data/raw/desc2021.xml

--- a/pipelines/bioasq/dvc.lock
+++ b/pipelines/bioasq/dvc.lock
@@ -1,0 +1,37 @@
+schema: '2.0'
+stages:
+  download:
+    cmd: python ../../scripts/download_bioasq_test_data.py 3 ../../data/processed/bioasq/data_3.json
+    deps:
+    - path: ../../scripts/download_bioasq_test_data.py
+      md5: dd7b13b49437977d68fee317acf4499d
+      size: 528
+    outs:
+    - path: ../../data/processed/bioasq/data_3.json
+      md5: ec91b529f6e8464255603001bed995c4
+      size: 7694765
+  tag:
+    cmd: python ../../scripts/tag_bioasq_test_data.py ../../data/processed/bioasq/data_3.json
+      ../../models/xlinear/model/ ../../models/xlinear/label_binarizer.pkl ../../data/raw/desc2021.xml
+      ../../data/processed/bioasq/tagged_data_3_xlinear.json --approach mesh-xlinear
+    deps:
+    - path: ../../data/processed/bioasq/data_3.json
+      md5: ec91b529f6e8464255603001bed995c4
+      size: 7694765
+    - path: ../../data/raw/desc2021.xml
+      md5: 8663a7dd8e1895dd22525d42b80cd2df
+      size: 300410104
+    - path: ../../models/xlinear/label_binarizer.pkl
+      md5: 67d759ed4142feab2e575dc9bd3d5f54
+      size: 827793
+    - path: ../../models/xlinear/model/
+      md5: 072d18f207a503c632e0ce7f363da070.dir
+      size: 3740297256
+      nfiles: 33
+    - path: ../../scripts/tag_bioasq_test_data.py
+      md5: fe0d5e489c45101738e5a62935837d9f
+      size: 1383
+    outs:
+    - path: ../../data/processed/bioasq/tagged_data_3_xlinear.json
+      md5: 4684b1bc9161d2035847a3d7519bf35e
+      size: 504262

--- a/pipelines/bioasq/dvc.lock
+++ b/pipelines/bioasq/dvc.lock
@@ -8,8 +8,8 @@ stages:
       size: 528
     outs:
     - path: ../../data/processed/bioasq/data_7.json
-      md5: 1b83feb67dfaada7ea87b396fe6e4deb
-      size: 182
+      md5: 88375afd5ba70d58eac3f850a9941c21
+      size: 7456404
   tag:
     cmd: python ../../scripts/tag_bioasq_test_data.py ../../data/processed/bioasq/data_3.json
       ../../models/xlinear/model/ ../../models/xlinear/label_binarizer.pkl ../../data/raw/desc2021.xml
@@ -35,3 +35,74 @@ stages:
     - path: ../../data/processed/bioasq/tagged_data_3_xlinear.json
       md5: 4684b1bc9161d2035847a3d7519bf35e
       size: 504262
+  tag@1:
+    cmd: python ../../scripts/tag_bioasq_test_data.py ../../data/processed/bioasq/data_7.json
+      ../../models/bertmesh/model.pt ../../models/bertmesh/label_binarizer.pkl ../../data/raw/desc2021.xml
+      ../../data/processed/bioasq/tagged_data_7_bertmesh.json --approach bertmesh
+      --threshold 0.5
+    deps:
+    - path: ../../data/processed/bioasq/data_7.json
+      md5: 88375afd5ba70d58eac3f850a9941c21
+      size: 7456404
+    - path: ../../data/raw/desc2021.xml
+      md5: 8663a7dd8e1895dd22525d42b80cd2df
+      size: 300410104
+    - path: ../../models/bertmesh/label_binarizer.pkl
+      md5: fc776931bd177c10b7831c05a9684a8b
+      size: 1038486
+    - path: ../../models/bertmesh/model.pt
+      md5: bb0216f0665ee2210aab1710daae48aa
+      size: 647482273
+    - path: ../../scripts/tag_bioasq_test_data.py
+      md5: fe0d5e489c45101738e5a62935837d9f
+      size: 1383
+    outs:
+    - path: ../../data/processed/bioasq/tagged_data_7_bertmesh.json
+      md5: c8922259f4b1a449e9556b83c42b9f93
+      size: 611749
+  submit@1:
+    cmd: python ../../scripts/submit_bioasq_test_results.py 7 ../../data/processed/bioasq/tagged_data_7_bertmesh.json
+      Wellcome-BertMesh
+    deps:
+    - path: ../../data/processed/bioasq/tagged_data_7_bertmesh.json
+      md5: c8922259f4b1a449e9556b83c42b9f93
+      size: 611749
+    - path: ../../scripts/submit_bioasq_test_results.py
+      md5: 81867d741804db4c1bbd6a70188b9817
+      size: 724
+  tag@0:
+    cmd: python ../../scripts/tag_bioasq_test_data.py ../../data/processed/bioasq/data_7.json
+      ../../models/xlinear/model/ ../../models/xlinear/label_binarizer.pkl ../../data/raw/desc2021.xml
+      ../../data/processed/bioasq/tagged_data_7_xlinear.json --approach mesh-xlinear
+      --threshold 0.2
+    deps:
+    - path: ../../data/processed/bioasq/data_7.json
+      md5: 88375afd5ba70d58eac3f850a9941c21
+      size: 7456404
+    - path: ../../data/raw/desc2021.xml
+      md5: 8663a7dd8e1895dd22525d42b80cd2df
+      size: 300410104
+    - path: ../../models/xlinear/label_binarizer.pkl
+      md5: 67d759ed4142feab2e575dc9bd3d5f54
+      size: 827793
+    - path: ../../models/xlinear/model/
+      md5: 072d18f207a503c632e0ce7f363da070.dir
+      size: 3740297256
+      nfiles: 33
+    - path: ../../scripts/tag_bioasq_test_data.py
+      md5: fe0d5e489c45101738e5a62935837d9f
+      size: 1383
+    outs:
+    - path: ../../data/processed/bioasq/tagged_data_7_xlinear.json
+      md5: 85575f8253aef0affefad78efbe84bd2
+      size: 627877
+  submit@0:
+    cmd: python ../../scripts/submit_bioasq_test_results.py 7 ../../data/processed/bioasq/tagged_data_7_xlinear.json
+      Wellcome-XLinear
+    deps:
+    - path: ../../data/processed/bioasq/tagged_data_7_xlinear.json
+      md5: 85575f8253aef0affefad78efbe84bd2
+      size: 627877
+    - path: ../../scripts/submit_bioasq_test_results.py
+      md5: 81867d741804db4c1bbd6a70188b9817
+      size: 724

--- a/pipelines/bioasq/dvc.yaml
+++ b/pipelines/bioasq/dvc.yaml
@@ -1,7 +1,8 @@
 vars:
-  - test_number: 3 # You need to also chage the numbers in the below paths
-  - data_path: "../../data/processed/bioasq/data_3.json"
+  - test_number: 7 # Need to update the number below as well as interpolation is not allowed
+  - data_path: "../../data/processed/bioasq/data_7.json"
   - mesh_metadata_path: "../../data/raw/desc2021.xml"
+
 stages:
   download:
     cmd:
@@ -17,13 +18,15 @@ stages:
         label_binarizer_path: "../../models/xlinear/label_binarizer.pkl"
         approach: "mesh-xlinear"
         tagged_data_path: "../../data/processed/bioasq/tagged_data_${test_number}_xlinear.json"
+        threshold: 0.2
       - model_path: "../../models/bertmesh/model.pt"
         label_binarizer_path: "../../models/bertmesh/label_binarizer.pkl"
         approach: "bertmesh"
         tagged_data_path: "../../data/processed/bioasq/tagged_data_${test_number}_bertmesh.json"
+        threshold: 0.5
     do:
       cmd:
-        python ../../scripts/tag_bioasq_test_data.py ${data_path} ${item.model_path} ${item.label_binarizer_path} ${mesh_metadata_path} ${item.tagged_data_path} --approach ${item.approach}
+        python ../../scripts/tag_bioasq_test_data.py ${data_path} ${item.model_path} ${item.label_binarizer_path} ${mesh_metadata_path} ${item.tagged_data_path} --approach ${item.approach} --threshold ${item.threshold}
       deps:
         - ${data_path}
         - ${mesh_metadata_path}

--- a/pipelines/bioasq/dvc.yaml
+++ b/pipelines/bioasq/dvc.yaml
@@ -1,0 +1,47 @@
+vars:
+  - test_number: 3 # You need to also chage the numbers in the below paths
+  - data_path: "../../data/processed/bioasq/data_3.json"
+  - mesh_metadata_path: "../../data/raw/desc2021.xml"
+stages:
+  download:
+    cmd:
+      python ../../scripts/download_bioasq_test_data.py ${test_number} ${data_path}
+    deps:
+      - ../../scripts/download_bioasq_test_data.py
+    outs:
+      - ${data_path}
+
+  tag:
+    foreach:
+      - model_path: "../../models/xlinear/model/"
+        label_binarizer_path: "../../models/xlinear/label_binarizer.pkl"
+        approach: "mesh-xlinear"
+        tagged_data_path: "../../data/processed/bioasq/tagged_data_${test_number}_xlinear.json"
+      - model_path: "../../models/bertmesh/model.pt"
+        label_binarizer_path: "../../models/bertmesh/label_binarizer.pkl"
+        approach: "bertmesh"
+        tagged_data_path: "../../data/processed/bioasq/tagged_data_${test_number}_bertmesh.json"
+    do:
+      cmd:
+        python ../../scripts/tag_bioasq_test_data.py ${data_path} ${item.model_path} ${item.label_binarizer_path} ${mesh_metadata_path} ${item.tagged_data_path} --approach ${item.approach}
+      deps:
+        - ${data_path}
+        - ${mesh_metadata_path}
+        - ${item.model_path}
+        - ${item.label_binarizer_path}
+        - ../../scripts/tag_bioasq_test_data.py
+      outs:
+        - ${item.tagged_data_path}
+
+  submit:
+    foreach:
+      - tagged_data_path: "../../data/processed/bioasq/tagged_data_${test_number}_xlinear.json"
+        system: "Wellcome-XLinear"
+      - tagged_data_path: "../../data/processed/bioasq/tagged_data_${test_number}_bertmesh.json"
+        system: "Wellcome-BertMesh"
+    do:
+      cmd:
+        python ../../scripts/submit_bioasq_test_results.py ${test_number} ${item.tagged_data_path} ${item.system}
+      deps:
+        - ../../scripts/submit_bioasq_test_results.py
+        - ${item.tagged_data_path}

--- a/scripts/download_bioasq_test_data.py
+++ b/scripts/download_bioasq_test_data.py
@@ -1,9 +1,10 @@
 import requests
 import typer
 import json
+import os
 
 
-def download_test_data(test_number, username, password, data_path):
+def download_test_data(test_number, data_path, username=os.environ.get("BIOASQ_USERNAME"), password=os.environ.get("BIOASQ_PASSWORD")):
     url = f"http://participants-area.bioasq.org/tests/{test_number}"
 
     response = requests.get(url, auth=(username, password))

--- a/scripts/submit_bioasq_test_results.py
+++ b/scripts/submit_bioasq_test_results.py
@@ -1,9 +1,10 @@
 import requests
 import typer
 import json
+import os
 
 
-def submit_test_results(test_number, tagged_data_path, system, username, password):
+def submit_test_results(test_number, tagged_data_path, system, username=os.environ["BIOASQ_USERNAME"], password=os.environ["BIOASQ_PASSWORD"]):
     with open(tagged_data_path) as f:
         tagged_data = json.load(f)
 

--- a/scripts/tag_bioasq_test_data.py
+++ b/scripts/tag_bioasq_test_data.py
@@ -22,7 +22,7 @@ def get_mesh2code(mesh_metadata_path):
             pass
     return mesh2code
 
-def tag_bioasq_data(data_path, model_path, label_binarizer_path, mesh_metadata_path, tagged_data_path, threshold=0.5):
+def tag_bioasq_data(data_path, model_path, label_binarizer_path, mesh_metadata_path, tagged_data_path, threshold:float=0.5, approach="mesh-xlinear"):
     with open(data_path) as f:
         data = json.load(f)
 
@@ -34,7 +34,7 @@ def tag_bioasq_data(data_path, model_path, label_binarizer_path, mesh_metadata_p
         X.append(item["title"] + " " + item["abstractText"])
         pmids.append(item["pmid"])
 
-    tags = predict_tags(X, model_path, label_binarizer_path, "mesh-xlinear", threshold=threshold)
+    tags = predict_tags(X, model_path, label_binarizer_path, approach, threshold=threshold)
     
     tagged_data = [{"pmid": pmid, "labels": [mesh2code[t] for t in tags_]} for pmid, tags_ in zip(pmids, tags)]
   


### PR DESCRIPTION
## Description

Adds BertMesh in models by copying and not refactoring the experimental code in BertMesh. The reason being that at this point we want to maintain moving fast in experimentation while separating what we maintain for "production". As such we do not add code to train BertMesh as this happens still in experimentation mode. Once this becomes more stable we can do that.

DVC sort of up to date.

## Checklist

- [ ] Linked to Notion or GitHub issue
- [x] Added tests
- [ ] Updated README
- [x] DVC up to date