### PR TITLE
Create pre-process for to toy data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,20 +9,20 @@ repos:
   rev: 22.3.0
   hooks:
   - id: black
-- repo: https://github.com/iterative/dvc
-  rev: 2.10.1
-  hooks:
-  - id: dvc-pre-commit
-    language_version: python3
-    stages:
-    - commit
-  - id: dvc-pre-push
-    additional_dependencies: ['.[all]']
-    language_version: python3
-    stages:
-    - push
-  - id: dvc-post-checkout
-    language_version: python3
-    stages:
-    - post-checkout
-    always_run: true
+#- repo: https://github.com/iterative/dvc
+#  rev: 2.10.1
+#  hooks:
+#  - id: dvc-pre-commit
+#    language_version: python3
+#    stages:
+#    - commit
+#  - id: dvc-pre-push
+#    additional_dependencies: ['.[all]']
+#    language_version: python3
+#    stages:
+#    - push
+#  - id: dvc-post-checkout
+#    language_version: python3
+#    stages:
+#    - post-checkout
+#    always_run: true

--- a/dvc.lock
+++ b/dvc.lock
@@ -335,3 +335,24 @@ stages:
     - path: data/raw/grants.csv
       md5: 9732c21dd1954cce8baaf3746f301ead
       size: 152523849
+  preprocess_bioasq_mesh_toy:
+    cmd: grants_tagger preprocess bioasq-mesh data/raw/allMeSH_2021.json data/processed/train_mesh2021_toy.jsonl
+      models/label_binarizer_toy.pkl --test-split 0.01 --test-output-path data/processed/test_mesh2021_toy.jsonl
+      --n-max 1000
+    deps:
+    - path: data/raw/allMeSH_2021.json
+      md5: e827a6b8062d1312664dcf075c12d89f
+      size: 27547042745
+    - path: grants_tagger/preprocess_mesh.py
+      md5: c03d969be5989ff0bc72db8e57ff9304
+      size: 5379
+    outs:
+    - path: data/processed/test_mesh2021_toy.jsonl
+      md5: 5878dee1d8d1af8849adfc145e2f5194
+      size: 177552565
+    - path: data/processed/train_mesh2021_toy.jsonl
+      md5: 1f1a8b7362316df6f7fcda88753ac331
+      size: 17575598357
+    - path: models/label_binarizer_toy.pkl
+      md5: c09a03fcaeeb0ffb7693187e06ace015
+      size: 621636

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -97,6 +97,17 @@ stages:
     - data/processed/train_mesh2021.jsonl
     - data/processed/test_mesh2021.jsonl
     - models/xlinear/label_binarizer.pkl
+  preprocess_bioasq_mesh_toy:  # Creates toy data to help iterating/testing code
+      cmd: grants_tagger preprocess bioasq-mesh data/raw/allMeSH_2021.json data/processed/train_mesh2021_toy.jsonl
+        models/label_binarizer_toy.pkl --test-split 0.01 --test-output-path data/processed/test_mesh2021_toy.jsonl
+        --n-max 1000
+      deps:
+        - data/raw/allMeSH_2021.json
+        - grants_tagger/preprocess_mesh.py
+      outs:
+        - data/processed/train_mesh2021_toy.jsonl
+        - data/processed/test_mesh2021_toy.jsonl
+        - models/label_binarizer_toy.pkl
   train_mesh_xlinear:
     cmd: grants_tagger train data/processed/train_mesh2021.jsonl
       models/xlinear/label_binarizer.pkl models/xlinear/model

--- a/grants_tagger/preprocess_mesh.py
+++ b/grants_tagger/preprocess_mesh.py
@@ -67,7 +67,11 @@ def yield_data(input_path, filter_tags, filter_years, buffer_size=10_000):
 
 
 def preprocess_mesh(
-    raw_data_path, processed_data_path, mesh_tags_path=None, filter_years=None
+    raw_data_path,
+    processed_data_path,
+    mesh_tags_path=None,
+    filter_years=None,
+    n_max=None,
 ):
     if mesh_tags_path:
         filter_tags_data = pd.read_csv(mesh_tags_path)
@@ -81,8 +85,12 @@ def preprocess_mesh(
         filter_years = [int(min_year), int(max_year)]
 
     with open(processed_data_path, "w") as f:
-        for data_batch in yield_data(raw_data_path, filter_tags, filter_years):
+        for i, data_batch in enumerate(
+            yield_data(raw_data_path, filter_tags, filter_years)
+        ):
             write_jsonl(f, data_batch)
+            if n_max and i > n_max:
+                break
 
 
 preprocess_mesh_app = typer.Typer()
@@ -111,6 +119,10 @@ def preprocess_mesh_cli(
     ),
     config: Optional[Path] = typer.Option(
         None, help="path to config files that defines arguments"
+    ),
+    n_max: Optional[int] = typer.Option(
+        None,
+        help="Maximum limit on the number of datapoints in the set (including training and test)",
     ),
 ):
 
@@ -151,6 +163,7 @@ def preprocess_mesh_cli(
         temporary_output_path,
         mesh_tags_path=mesh_tags_path,
         filter_years=filter_years,
+        n_max=n_max,
     )
     create_label_binarizer(temporary_output_path, label_binarizer_path, sparse=True)
 


### PR DESCRIPTION
## Description

Adds a process to generate toy MeSH data, alongside real data, so we can iterate our code faster. 

It disables/comments the dvc pre-commit hook because I will make a lot of changes to it, so no point in re-running every time.

## Checklist

- [ ] Linked to Notion or GitHub issue
- [ ] Added tests
- [ ] Updated README
- [ ] DVC up to date

## Release checklist

- [ ] DVC repro up to date
- [ ] Models synced in S3
- [ ] Version updated
- [ ] CHANGELOG.md updated
- [ ] Model and package version aligned

To release:

* `make build`
* `make deploy`
